### PR TITLE
[application] Support out-of-order nonce execution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
 
   dependencies:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/bin/validator/src/relayer.rs
+++ b/bin/validator/src/relayer.rs
@@ -422,6 +422,7 @@ async fn account(
 struct AccountResponse {
     balance: u64,
     nonce: u64,
+    nonce_bitmap: u64,
 }
 
 impl From<Account> for AccountResponse {
@@ -429,6 +430,7 @@ impl From<Account> for AccountResponse {
         Self {
             balance: account.balance,
             nonce: account.nonce,
+            nonce_bitmap: account.nonce_bitmap,
         }
     }
 }

--- a/bin/validator/src/relayer.rs
+++ b/bin/validator/src/relayer.rs
@@ -15,7 +15,7 @@ use commonware_cryptography::{Hasher, bls12381::primitives::variant::MinSig, ed2
 use commonware_formatting::from_hex;
 use constantinople_engine::types::EngineActivity;
 use constantinople_mempool::webserver::{AccountReader, TxStatus};
-use constantinople_primitives::{Account, SignedTransaction, TransactionPublicKey};
+use constantinople_primitives::{Account, Nonce, SignedTransaction, TransactionPublicKey};
 use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -421,16 +421,29 @@ async fn account(
 #[derive(Serialize)]
 struct AccountResponse {
     balance: u64,
-    nonce: u64,
-    nonce_bitmap: u64,
+    nonce: NonceResponse,
+}
+
+#[derive(Serialize)]
+struct NonceResponse {
+    base: u64,
+    bitmap: u64,
 }
 
 impl From<Account> for AccountResponse {
     fn from(account: Account) -> Self {
         Self {
             balance: account.balance,
-            nonce: account.nonce,
-            nonce_bitmap: account.nonce_bitmap,
+            nonce: NonceResponse::from(account.nonce),
+        }
+    }
+}
+
+impl From<Nonce> for NonceResponse {
+    fn from(nonce: Nonce) -> Self {
+        Self {
+            base: nonce.base,
+            bitmap: nonce.bitmap,
         }
     }
 }

--- a/crates/application/benches/consensus.rs
+++ b/crates/application/benches/consensus.rs
@@ -33,8 +33,8 @@ use commonware_utils::{
 use constantinople_application::consensus::{Application, TransactionHistoryDb};
 use constantinople_mempool::mocks::StaticTransactionSource;
 use constantinople_primitives::{
-    Account, AccountKey, Block, BlockCfg, Header, Sealable, SealedBlock, TRANSACTION_NAMESPACE,
-    Transaction, TransactionPublicKey, VerifiedTransaction,
+    Account, AccountKey, Block, BlockCfg, Header, Nonce, Sealable, SealedBlock,
+    TRANSACTION_NAMESPACE, Transaction, TransactionPublicKey, VerifiedTransaction,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::{
@@ -471,8 +471,7 @@ impl GeneratedTransactions {
                 AccountKey::from_public_key(&sender_public_key),
                 Account {
                     balance: 1,
-                    nonce: 0,
-                    nonce_bitmap: 0,
+                    nonce: Nonce::default(),
                 },
             ));
             accounts.push((

--- a/crates/application/benches/consensus.rs
+++ b/crates/application/benches/consensus.rs
@@ -472,6 +472,7 @@ impl GeneratedTransactions {
                 Account {
                     balance: 1,
                     nonce: 0,
+                    nonce_bitmap: 0,
                 },
             ));
             accounts.push((

--- a/crates/application/benches/executor.rs
+++ b/crates/application/benches/executor.rs
@@ -58,6 +58,7 @@ fn build_fixture(transaction_count: usize) -> (State, Vec<TestTransaction>) {
             Account {
                 balance: 1,
                 nonce: 0,
+                nonce_bitmap: 0,
             },
         );
         accounts.insert(

--- a/crates/application/benches/executor.rs
+++ b/crates/application/benches/executor.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{Signer, ed25519, sha256};
 use commonware_math::algebra::Random;
 use constantinople_application::executor::{self, State};
 use constantinople_primitives::{
-    Account, AccountKey, Transaction, TransactionPublicKey, VerifiedTransaction,
+    Account, AccountKey, Nonce, Transaction, TransactionPublicKey, VerifiedTransaction,
 };
 use core::num::NonZeroU64;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -57,8 +57,7 @@ fn build_fixture(transaction_count: usize) -> (State, Vec<TestTransaction>) {
             AccountKey::from_public_key(&sender_public_key),
             Account {
                 balance: 1,
-                nonce: 0,
-                nonce_bitmap: 0,
+                nonce: Nonce::default(),
             },
         );
         accounts.insert(

--- a/crates/application/src/executor.rs
+++ b/crates/application/src/executor.rs
@@ -174,15 +174,13 @@ where
 
     for (transfer, accounts) in transfers.iter().zip(accounts.chunks_exact(2)) {
         let mut sender = accounts[0];
-        if sender.nonce != transfer.nonce || sender.balance < transfer.value {
+        if sender.balance < transfer.value || !sender.use_nonce(transfer.nonce) {
             return None;
         }
-        let next_nonce = sender.nonce.checked_add(1)?;
 
         let mut recipient = accounts[1];
         let recipient_balance = recipient.balance.checked_add(transfer.value)?;
 
-        sender.nonce = next_nonce;
         sender.balance -= transfer.value;
         recipient.balance = recipient_balance;
         changeset.push((transfer.sender.clone(), sender));
@@ -241,14 +239,10 @@ where
     let Some(mut sender) = state.get(&transfer.sender) else {
         return false;
     };
-    if sender.nonce != transfer.nonce || sender.balance < transfer.value {
+    if sender.balance < transfer.value || !sender.use_nonce(transfer.nonce) {
         return false;
     }
-    let Some(next_nonce) = sender.nonce.checked_add(1) else {
-        return false;
-    };
 
-    sender.nonce = next_nonce;
     if transfer.sender == transfer.recipient {
         state.set(transfer.sender.clone(), sender);
         return true;

--- a/crates/application/src/executor.rs
+++ b/crates/application/src/executor.rs
@@ -174,7 +174,7 @@ where
 
     for (transfer, accounts) in transfers.iter().zip(accounts.chunks_exact(2)) {
         let mut sender = accounts[0];
-        if sender.balance < transfer.value || !sender.use_nonce(transfer.nonce) {
+        if sender.balance < transfer.value || !sender.nonce.consume(transfer.nonce) {
             return None;
         }
 
@@ -239,7 +239,7 @@ where
     let Some(mut sender) = state.get(&transfer.sender) else {
         return false;
     };
-    if sender.balance < transfer.value || !sender.use_nonce(transfer.nonce) {
+    if sender.balance < transfer.value || !sender.nonce.consume(transfer.nonce) {
         return false;
     }
 

--- a/crates/application/src/executor/tests.rs
+++ b/crates/application/src/executor/tests.rs
@@ -1,7 +1,8 @@
 use super::{ProposalOutput, State, execute, execute_unique, prepare_transfer, propose};
 use commonware_cryptography::{Signer, ed25519, sha256};
 use constantinople_primitives::{
-    Account, AccountKey, Transaction, TransactionPublicKey, VerifiedTransaction,
+    Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY, Transaction,
+    TransactionPublicKey, VerifiedTransaction,
 };
 use core::num::NonZeroU64;
 
@@ -36,7 +37,11 @@ impl TestSigner {
 }
 
 fn account(balance: u64, nonce: u64) -> Account {
-    Account { balance, nonce }
+    Account {
+        balance,
+        nonce,
+        nonce_bitmap: 0,
+    }
 }
 
 fn account_key(public_key: &ed25519::PublicKey) -> AccountKey {
@@ -73,6 +78,77 @@ fn proposal_tracks_pending_nonce_and_balance() {
     assert_eq!(proposal.valid[0].value().nonce, 0);
     assert_eq!(proposal.valid[1].value().nonce, 1);
     assert_eq!(proposal.invalid[0].value().value.get(), 7);
+}
+
+#[test]
+fn proposal_accepts_nonce_inside_run_ahead_window() {
+    let signer = TestSigner::from_seed(2);
+    let recipient = TestSigner::from_seed(3);
+    let mut accounts = State::new();
+    accounts.insert(account_key(&signer.public_key), account(10, 0));
+    accounts.insert(account_key(&recipient.public_key), Account::default());
+
+    let transactions = vec![
+        signer.sign(recipient.public_key.clone(), 3, 2),
+        signer.sign(recipient.public_key.clone(), 4, 0),
+        signer.sign(recipient.public_key.clone(), 2, 1),
+    ];
+    let proposal = propose(&accounts, transactions);
+    let sender = changeset_account(&proposal.changeset, signer.public_key)
+        .expect("sender should be updated");
+    let recipient = changeset_account(&proposal.changeset, recipient.public_key)
+        .expect("recipient should be updated");
+
+    assert_eq!(proposal.valid.len(), 3);
+    assert!(proposal.invalid.is_empty());
+    assert_eq!(sender.balance, 1);
+    assert_eq!(sender.nonce, 3);
+    assert_eq!(recipient.balance, DEFAULT_ACCOUNT_BALANCE + 9);
+}
+
+#[test]
+fn proposal_rejects_duplicate_run_ahead_nonce() {
+    let signer = TestSigner::from_seed(4);
+    let recipient = TestSigner::from_seed(5);
+    let mut accounts = State::new();
+    accounts.insert(account_key(&signer.public_key), account(10, 0));
+    accounts.insert(account_key(&recipient.public_key), Account::default());
+
+    let transactions = vec![
+        signer.sign(recipient.public_key.clone(), 3, 2),
+        signer.sign(recipient.public_key, 4, 2),
+    ];
+    let proposal = propose(&accounts, transactions);
+    let sender = changeset_account(&proposal.changeset, signer.public_key)
+        .expect("sender should be updated");
+
+    assert_eq!(proposal.valid.len(), 1);
+    assert_eq!(proposal.invalid.len(), 1);
+    assert_eq!(sender.balance, 7);
+    assert_eq!(sender.nonce, 0);
+}
+
+#[test]
+fn proposal_accepts_far_ahead_nonce_and_rejects_duplicate() {
+    let signer = TestSigner::from_seed(6);
+    let recipient = TestSigner::from_seed(7);
+    let mut accounts = State::new();
+    accounts.insert(account_key(&signer.public_key), account(10, 0));
+    accounts.insert(account_key(&recipient.public_key), Account::default());
+
+    let nonce = NONCE_BITMAP_CAPACITY + 1;
+    let transactions = vec![
+        signer.sign(recipient.public_key.clone(), 3, nonce),
+        signer.sign(recipient.public_key, 4, nonce),
+    ];
+    let proposal = propose(&accounts, transactions);
+    let sender = changeset_account(&proposal.changeset, signer.public_key)
+        .expect("sender should be updated");
+
+    assert_eq!(proposal.valid.len(), 1);
+    assert_eq!(proposal.invalid.len(), 1);
+    assert_eq!(sender.balance, 7);
+    assert_eq!(sender.nonce, NONCE_BITMAP_CAPACITY + 2);
 }
 
 #[test]

--- a/crates/application/src/executor/tests.rs
+++ b/crates/application/src/executor/tests.rs
@@ -1,7 +1,7 @@
 use super::{ProposalOutput, State, execute, execute_unique, prepare_transfer, propose};
 use commonware_cryptography::{Signer, ed25519, sha256};
 use constantinople_primitives::{
-    Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY, Transaction,
+    Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY, Nonce, Transaction,
     TransactionPublicKey, VerifiedTransaction,
 };
 use core::num::NonZeroU64;
@@ -39,8 +39,7 @@ impl TestSigner {
 fn account(balance: u64, nonce: u64) -> Account {
     Account {
         balance,
-        nonce,
-        nonce_bitmap: 0,
+        nonce: Nonce::new(nonce, 0),
     }
 }
 
@@ -102,7 +101,7 @@ fn proposal_accepts_nonce_inside_run_ahead_window() {
     assert_eq!(proposal.valid.len(), 3);
     assert!(proposal.invalid.is_empty());
     assert_eq!(sender.balance, 1);
-    assert_eq!(sender.nonce, 3);
+    assert_eq!(sender.nonce.base, 3);
     assert_eq!(recipient.balance, DEFAULT_ACCOUNT_BALANCE + 9);
 }
 
@@ -125,7 +124,7 @@ fn proposal_rejects_duplicate_run_ahead_nonce() {
     assert_eq!(proposal.valid.len(), 1);
     assert_eq!(proposal.invalid.len(), 1);
     assert_eq!(sender.balance, 7);
-    assert_eq!(sender.nonce, 0);
+    assert_eq!(sender.nonce.base, 0);
 }
 
 #[test]
@@ -148,7 +147,7 @@ fn proposal_accepts_far_ahead_nonce_and_rejects_duplicate() {
     assert_eq!(proposal.valid.len(), 1);
     assert_eq!(proposal.invalid.len(), 1);
     assert_eq!(sender.balance, 7);
-    assert_eq!(sender.nonce, NONCE_BITMAP_CAPACITY + 2);
+    assert_eq!(sender.nonce.base, NONCE_BITMAP_CAPACITY + 2);
 }
 
 #[test]

--- a/crates/indexer/src/publisher/qmdb.rs
+++ b/crates/indexer/src/publisher/qmdb.rs
@@ -1626,7 +1626,7 @@ mod tests {
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, non_empty_range};
     use constantinople_primitives::{
-        Block, Header, Sealable, SignedTransaction, TRANSACTION_NAMESPACE, Transaction,
+        Block, Header, Nonce, Sealable, SignedTransaction, TRANSACTION_NAMESPACE, Transaction,
         TransactionPublicKey,
     };
     use exoware_sdk::RetryConfig;
@@ -1712,8 +1712,7 @@ mod tests {
                     key,
                     encode_account(Account {
                         balance: u64::from(seed),
-                        nonce: 0,
-                        nonce_bitmap: 0,
+                        nonce: Nonce::default(),
                     }),
                 )),
                 StateOperation::CommitFloor(None, Location::new(0)),
@@ -2055,16 +2054,14 @@ mod tests {
                         account_key(1),
                         Account {
                             balance: 10,
-                            nonce: 0,
-                            nonce_bitmap: 0,
+                            nonce: Nonce::default(),
                         },
                     ),
                     (
                         account_key(2),
                         Account {
                             balance: 20,
-                            nonce: 0,
-                            nonce_bitmap: 0,
+                            nonce: Nonce::default(),
                         },
                     ),
                 ],
@@ -2090,16 +2087,14 @@ mod tests {
                         account_key(1),
                         Account {
                             balance: 9,
-                            nonce: 1,
-                            nonce_bitmap: 0,
+                            nonce: Nonce::new(1, 0),
                         },
                     ),
                     (
                         account_key(3),
                         Account {
                             balance: 30,
-                            nonce: 0,
-                            nonce_bitmap: 0,
+                            nonce: Nonce::default(),
                         },
                     ),
                 ],
@@ -2448,8 +2443,7 @@ mod tests {
                 key,
                 encode_account(Account {
                     balance: u64::from(seed),
-                    nonce: 0,
-                    nonce_bitmap: 0,
+                    nonce: Nonce::default(),
                 }),
             )),
             StateOperation::CommitFloor(None, Location::new(0)),
@@ -2487,8 +2481,7 @@ mod tests {
                 account_key,
                 encode_account(Account {
                     balance: 1,
-                    nonce: 0,
-                    nonce_bitmap: 0,
+                    nonce: Nonce::default(),
                 }),
             )),
             StateOperation::CommitFloor(None, Location::new(0)),

--- a/crates/indexer/src/publisher/qmdb.rs
+++ b/crates/indexer/src/publisher/qmdb.rs
@@ -1394,7 +1394,7 @@ fn account_rows(delta: &[StateOperation], start_location: u64) -> Vec<super::Sql
         rows.push(encode_account_meta_row(AccountMetaRow {
             account: account_key_array(key),
             balance: account_value_balance(account),
-            nonce: account_value_nonce(account),
+            nonce_base: account_value_nonce_base(account),
             nonce_bitmap: account_value_nonce_bitmap(account),
             qmdb_location: location,
         }));
@@ -1415,10 +1415,10 @@ fn account_value_balance(account: &AccountValue) -> u64 {
     u64::from_be_bytes(bytes)
 }
 
-fn account_value_nonce(account: &AccountValue) -> u64 {
+fn account_value_nonce_base(account: &AccountValue) -> u64 {
     let bytes: [u8; 8] = account.as_ref()[8..16]
         .try_into()
-        .expect("account nonce has fixed width");
+        .expect("account nonce base has fixed width");
     u64::from_be_bytes(bytes)
 }
 

--- a/crates/indexer/src/publisher/qmdb.rs
+++ b/crates/indexer/src/publisher/qmdb.rs
@@ -1395,6 +1395,7 @@ fn account_rows(delta: &[StateOperation], start_location: u64) -> Vec<super::Sql
             account: account_key_array(key),
             balance: account_value_balance(account),
             nonce: account_value_nonce(account),
+            nonce_bitmap: account_value_nonce_bitmap(account),
             qmdb_location: location,
         }));
     }
@@ -1418,6 +1419,13 @@ fn account_value_nonce(account: &AccountValue) -> u64 {
     let bytes: [u8; 8] = account.as_ref()[8..16]
         .try_into()
         .expect("account nonce has fixed width");
+    u64::from_be_bytes(bytes)
+}
+
+fn account_value_nonce_bitmap(account: &AccountValue) -> u64 {
+    let bytes: [u8; 8] = account.as_ref()[16..24]
+        .try_into()
+        .expect("account nonce bitmap has fixed width");
     u64::from_be_bytes(bytes)
 }
 
@@ -1705,6 +1713,7 @@ mod tests {
                     encode_account(Account {
                         balance: u64::from(seed),
                         nonce: 0,
+                        nonce_bitmap: 0,
                     }),
                 )),
                 StateOperation::CommitFloor(None, Location::new(0)),
@@ -2047,6 +2056,7 @@ mod tests {
                         Account {
                             balance: 10,
                             nonce: 0,
+                            nonce_bitmap: 0,
                         },
                     ),
                     (
@@ -2054,6 +2064,7 @@ mod tests {
                         Account {
                             balance: 20,
                             nonce: 0,
+                            nonce_bitmap: 0,
                         },
                     ),
                 ],
@@ -2080,6 +2091,7 @@ mod tests {
                         Account {
                             balance: 9,
                             nonce: 1,
+                            nonce_bitmap: 0,
                         },
                     ),
                     (
@@ -2087,6 +2099,7 @@ mod tests {
                         Account {
                             balance: 30,
                             nonce: 0,
+                            nonce_bitmap: 0,
                         },
                     ),
                 ],
@@ -2436,6 +2449,7 @@ mod tests {
                 encode_account(Account {
                     balance: u64::from(seed),
                     nonce: 0,
+                    nonce_bitmap: 0,
                 }),
             )),
             StateOperation::CommitFloor(None, Location::new(0)),
@@ -2474,6 +2488,7 @@ mod tests {
                 encode_account(Account {
                     balance: 1,
                     nonce: 0,
+                    nonce_bitmap: 0,
                 }),
             )),
             StateOperation::CommitFloor(None, Location::new(0)),

--- a/crates/indexer/src/publisher/sql.rs
+++ b/crates/indexer/src/publisher/sql.rs
@@ -63,7 +63,7 @@ pub(crate) struct TxActivityRow {
 pub(crate) struct AccountMetaRow {
     pub account: [u8; 32],
     pub balance: u64,
-    pub nonce: u64,
+    pub nonce_base: u64,
     pub nonce_bitmap: u64,
     pub qmdb_location: u64,
 }
@@ -129,7 +129,7 @@ pub(crate) fn encode_account_meta_row(account: AccountMetaRow) -> SqlRow {
         values: vec![
             CellValue::FixedBinary(account.account.to_vec()),
             CellValue::UInt64(account.balance),
-            CellValue::UInt64(account.nonce),
+            CellValue::UInt64(account.nonce_base),
             CellValue::UInt64(account.nonce_bitmap),
             CellValue::UInt64(account.qmdb_location),
         ],

--- a/crates/indexer/src/publisher/sql.rs
+++ b/crates/indexer/src/publisher/sql.rs
@@ -64,6 +64,7 @@ pub(crate) struct AccountMetaRow {
     pub account: [u8; 32],
     pub balance: u64,
     pub nonce: u64,
+    pub nonce_bitmap: u64,
     pub qmdb_location: u64,
 }
 
@@ -129,6 +130,7 @@ pub(crate) fn encode_account_meta_row(account: AccountMetaRow) -> SqlRow {
             CellValue::FixedBinary(account.account.to_vec()),
             CellValue::UInt64(account.balance),
             CellValue::UInt64(account.nonce),
+            CellValue::UInt64(account.nonce_bitmap),
             CellValue::UInt64(account.qmdb_location),
         ],
     }

--- a/crates/indexer/src/sql_schema.rs
+++ b/crates/indexer/src/sql_schema.rs
@@ -86,6 +86,8 @@ pub const ACCOUNT_META_ACCOUNT: &str = "account";
 pub const ACCOUNT_META_BALANCE: &str = "balance";
 /// `account_meta`: indexed account nonce.
 pub const ACCOUNT_META_NONCE: &str = "nonce";
+/// `account_meta`: indexed account run-ahead nonce bitmap.
+pub const ACCOUNT_META_NONCE_BITMAP: &str = "nonce_bitmap";
 /// `account_meta`: account-state QMDB operation location.
 pub const ACCOUNT_META_QMDB_LOCATION: &str = "qmdb_location";
 
@@ -182,6 +184,7 @@ pub fn build_meta_schema(client: StoreClient) -> Result<KvSchema, String> {
                     ),
                     TableColumnConfig::new(ACCOUNT_META_BALANCE, DataType::UInt64, false),
                     TableColumnConfig::new(ACCOUNT_META_NONCE, DataType::UInt64, false),
+                    TableColumnConfig::new(ACCOUNT_META_NONCE_BITMAP, DataType::UInt64, false),
                     TableColumnConfig::new(ACCOUNT_META_QMDB_LOCATION, DataType::UInt64, false),
                 ],
                 vec![ACCOUNT_META_ACCOUNT.to_string()],
@@ -258,6 +261,7 @@ mod tests {
         assert_eq!(ACCOUNT_META_ACCOUNT, "account");
         assert_eq!(ACCOUNT_META_BALANCE, "balance");
         assert_eq!(ACCOUNT_META_NONCE, "nonce");
+        assert_eq!(ACCOUNT_META_NONCE_BITMAP, "nonce_bitmap");
         assert_eq!(ACCOUNT_META_QMDB_LOCATION, "qmdb_location");
     }
 }

--- a/crates/indexer/src/sql_schema.rs
+++ b/crates/indexer/src/sql_schema.rs
@@ -84,8 +84,8 @@ pub const TX_ACTIVITY_NONCE: &str = "nonce";
 pub const ACCOUNT_META_ACCOUNT: &str = "account";
 /// `account_meta`: indexed account balance.
 pub const ACCOUNT_META_BALANCE: &str = "balance";
-/// `account_meta`: indexed account nonce.
-pub const ACCOUNT_META_NONCE: &str = "nonce";
+/// `account_meta`: indexed account nonce base.
+pub const ACCOUNT_META_NONCE_BASE: &str = "nonce_base";
 /// `account_meta`: indexed account run-ahead nonce bitmap.
 pub const ACCOUNT_META_NONCE_BITMAP: &str = "nonce_bitmap";
 /// `account_meta`: account-state QMDB operation location.
@@ -183,7 +183,7 @@ pub fn build_meta_schema(client: StoreClient) -> Result<KvSchema, String> {
                         false,
                     ),
                     TableColumnConfig::new(ACCOUNT_META_BALANCE, DataType::UInt64, false),
-                    TableColumnConfig::new(ACCOUNT_META_NONCE, DataType::UInt64, false),
+                    TableColumnConfig::new(ACCOUNT_META_NONCE_BASE, DataType::UInt64, false),
                     TableColumnConfig::new(ACCOUNT_META_NONCE_BITMAP, DataType::UInt64, false),
                     TableColumnConfig::new(ACCOUNT_META_QMDB_LOCATION, DataType::UInt64, false),
                 ],
@@ -260,7 +260,7 @@ mod tests {
         assert_eq!(TX_ACTIVITY_NONCE, "nonce");
         assert_eq!(ACCOUNT_META_ACCOUNT, "account");
         assert_eq!(ACCOUNT_META_BALANCE, "balance");
-        assert_eq!(ACCOUNT_META_NONCE, "nonce");
+        assert_eq!(ACCOUNT_META_NONCE_BASE, "nonce_base");
         assert_eq!(ACCOUNT_META_NONCE_BITMAP, "nonce_bitmap");
         assert_eq!(ACCOUNT_META_QMDB_LOCATION, "qmdb_location");
     }

--- a/crates/mempool/src/webserver/client.rs
+++ b/crates/mempool/src/webserver/client.rs
@@ -164,6 +164,7 @@ impl Client {
 pub struct AccountView {
     pub balance: u64,
     pub nonce: u64,
+    pub nonce_bitmap: u64,
 }
 
 /// Fast-ingest acknowledgement returned by validators.

--- a/crates/mempool/src/webserver/client.rs
+++ b/crates/mempool/src/webserver/client.rs
@@ -163,11 +163,11 @@ impl Client {
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct AccountView {
     pub balance: u64,
-    pub nonce: AccountNonceView,
+    pub nonce: NonceView,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
-pub struct AccountNonceView {
+pub struct NonceView {
     pub base: u64,
     pub bitmap: u64,
 }

--- a/crates/mempool/src/webserver/client.rs
+++ b/crates/mempool/src/webserver/client.rs
@@ -163,8 +163,13 @@ impl Client {
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct AccountView {
     pub balance: u64,
-    pub nonce: u64,
-    pub nonce_bitmap: u64,
+    pub nonce: AccountNonceView,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct AccountNonceView {
+    pub base: u64,
+    pub bitmap: u64,
 }
 
 /// Fast-ingest acknowledgement returned by validators.

--- a/crates/mempool/src/webserver/http.rs
+++ b/crates/mempool/src/webserver/http.rs
@@ -16,8 +16,8 @@ use commonware_cryptography::{Digest, Hasher, PublicKey};
 use commonware_formatting::from_hex;
 use commonware_parallel::Strategy;
 use constantinople_primitives::{
-    Account, LazySignedTransaction, SignedTransaction, TransactionPublicKey, TransactionSignature,
-    VerifiedTransaction, verify_transaction_chunks,
+    Account, LazySignedTransaction, Nonce, SignedTransaction, TransactionPublicKey,
+    TransactionSignature, VerifiedTransaction, verify_transaction_chunks,
 };
 use rand_core::OsRng;
 use std::{fmt::Display, sync::Arc};
@@ -379,16 +379,29 @@ where
 #[derive(serde::Serialize)]
 struct AccountResponse {
     balance: u64,
-    nonce: u64,
-    nonce_bitmap: u64,
+    nonce: NonceResponse,
+}
+
+#[derive(serde::Serialize)]
+struct NonceResponse {
+    base: u64,
+    bitmap: u64,
 }
 
 impl From<Account> for AccountResponse {
     fn from(account: Account) -> Self {
         Self {
             balance: account.balance,
-            nonce: account.nonce,
-            nonce_bitmap: account.nonce_bitmap,
+            nonce: NonceResponse::from(account.nonce),
+        }
+    }
+}
+
+impl From<Nonce> for NonceResponse {
+    fn from(nonce: Nonce) -> Self {
+        Self {
+            base: nonce.base,
+            bitmap: nonce.bitmap,
         }
     }
 }

--- a/crates/mempool/src/webserver/http.rs
+++ b/crates/mempool/src/webserver/http.rs
@@ -334,7 +334,7 @@ where
 /// Returns the committed account for the hex-encoded public key.
 ///
 /// Responds with:
-/// - `200 OK` and `{"balance": u64, "nonce": u64}` if the account exists.
+/// - `200 OK` and account JSON if the account exists.
 /// - `404 Not Found` if the account has not been written.
 /// - `400 Bad Request` if the path is not a valid public key hex string.
 /// - `503 Service Unavailable` if the state database has not been attached yet.
@@ -380,6 +380,7 @@ where
 struct AccountResponse {
     balance: u64,
     nonce: u64,
+    nonce_bitmap: u64,
 }
 
 impl From<Account> for AccountResponse {
@@ -387,6 +388,7 @@ impl From<Account> for AccountResponse {
         Self {
             balance: account.balance,
             nonce: account.nonce,
+            nonce_bitmap: account.nonce_bitmap,
         }
     }
 }

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -15,6 +15,9 @@ use derive_more::{Debug, Display};
 /// Default starting balance for accounts that have not been written yet.
 pub const DEFAULT_ACCOUNT_BALANCE: u64 = 100;
 
+/// Number of future nonce uses tracked on each account.
+pub const NONCE_BITMAP_CAPACITY: u64 = u64::BITS as u64;
+
 /// Fixed-width account identifier derived from a transaction public key.
 ///
 /// Unlike [`commonware_cryptography::PublicKey`] implementations, decoding an
@@ -117,14 +120,41 @@ impl Array for AccountKey {}
 /// An account, as represented in the state of the chain.
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
-#[display("Account {{ balance: {}, nonce: {} }}", balance, nonce)]
+#[display(
+    "Account {{ balance: {}, nonce: {}, nonce_bitmap: {} }}",
+    balance,
+    nonce,
+    nonce_bitmap
+)]
 pub struct Account {
     /// The balance of the account, which is the amount of tokens that the
     /// account holds.
     pub balance: u64,
-    /// The nonce of the account, which is incremented every time a
-    /// transaction is sent from the account.
+    /// The next nonce that has not been consumed by this account.
     pub nonce: u64,
+    /// Used future nonces relative to [`Self::nonce`].
+    ///
+    /// Bit 0 records `nonce + 1`, and bit 63 records `nonce + 64`.
+    pub nonce_bitmap: u64,
+}
+
+impl Account {
+    /// Records a transaction nonce if it has not already been consumed.
+    ///
+    /// Nonces below [`Self::nonce`] are stale. Nonces inside the run-ahead
+    /// window set a bitmap bit. Nonces beyond the window clear the bitmap and
+    /// advance [`Self::nonce`] beyond the consumed transaction.
+    pub fn use_nonce(&mut self, nonce: u64) -> bool {
+        let Some((next_nonce, next_bitmap)) =
+            next_nonce_state(self.nonce, self.nonce_bitmap, nonce)
+        else {
+            return false;
+        };
+
+        self.nonce = next_nonce;
+        self.nonce_bitmap = next_bitmap;
+        true
+    }
 }
 
 impl Default for Account {
@@ -132,18 +162,20 @@ impl Default for Account {
         Self {
             balance: DEFAULT_ACCOUNT_BALANCE,
             nonce: 0,
+            nonce_bitmap: 0,
         }
     }
 }
 
 impl FixedSize for Account {
-    const SIZE: usize = u64::SIZE + u64::SIZE;
+    const SIZE: usize = u64::SIZE + u64::SIZE + u64::SIZE;
 }
 
 impl Write for Account {
     fn write(&self, buf: &mut impl BufMut) {
         self.balance.write(buf);
         self.nonce.write(buf);
+        self.nonce_bitmap.write(buf);
     }
 }
 
@@ -154,8 +186,52 @@ impl Read for Account {
         Ok(Self {
             balance: u64::read(buf)?,
             nonce: u64::read(buf)?,
+            nonce_bitmap: u64::read(buf)?,
         })
     }
+}
+
+fn next_nonce_state(base: u64, bitmap: u64, nonce: u64) -> Option<(u64, u64)> {
+    let next_used_nonce = nonce.checked_add(1)?;
+
+    if nonce < base {
+        return None;
+    }
+
+    let delta = nonce - base;
+    if delta == 0 {
+        return consume_current_nonce(base, bitmap);
+    }
+
+    if delta > NONCE_BITMAP_CAPACITY {
+        return Some((next_used_nonce, 0));
+    }
+
+    let bit = 1u64 << (delta - 1);
+    if bitmap & bit != 0 {
+        return None;
+    }
+
+    Some((base, bitmap | bit))
+}
+
+fn consume_current_nonce(base: u64, bitmap: u64) -> Option<(u64, u64)> {
+    let mut advance = 1;
+    while advance <= NONCE_BITMAP_CAPACITY {
+        let bit = 1u64 << (advance - 1);
+        if bitmap & bit == 0 {
+            break;
+        }
+        advance += 1;
+    }
+
+    let nonce = base.checked_add(advance)?;
+    let bitmap = if advance >= NONCE_BITMAP_CAPACITY {
+        0
+    } else {
+        bitmap >> advance
+    };
+    Some((nonce, bitmap))
 }
 
 #[cfg(test)]
@@ -204,6 +280,7 @@ mod tests {
         let account = Account {
             balance: 42,
             nonce: 7,
+            nonce_bitmap: 3,
         };
 
         let mut buf = Vec::with_capacity(Account::SIZE);
@@ -221,7 +298,65 @@ mod tests {
             Account {
                 balance: DEFAULT_ACCOUNT_BALANCE,
                 nonce: 0,
+                nonce_bitmap: 0,
             }
         );
+    }
+
+    #[test]
+    fn account_use_nonce_records_run_ahead_nonce() {
+        let mut account = Account::default();
+
+        assert!(account.use_nonce(2));
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.nonce_bitmap, 0b10);
+    }
+
+    #[test]
+    fn account_use_nonce_compacts_contiguous_run_ahead() {
+        let mut account = Account::default();
+
+        assert!(account.use_nonce(2));
+        assert!(account.use_nonce(0));
+        assert_eq!(account.nonce, 1);
+        assert_eq!(account.nonce_bitmap, 0b1);
+
+        assert!(account.use_nonce(1));
+        assert_eq!(account.nonce, 3);
+        assert_eq!(account.nonce_bitmap, 0);
+    }
+
+    #[test]
+    fn account_use_nonce_rejects_duplicate_run_ahead() {
+        let mut account = Account::default();
+
+        assert!(account.use_nonce(2));
+        assert!(!account.use_nonce(2));
+        assert_eq!(account.nonce, 0);
+        assert_eq!(account.nonce_bitmap, 0b10);
+    }
+
+    #[test]
+    fn account_use_nonce_rejects_run_ahead_nonce_that_cannot_advance() {
+        let mut account = Account {
+            balance: 0,
+            nonce: u64::MAX - 1,
+            nonce_bitmap: 0,
+        };
+
+        assert!(!account.use_nonce(u64::MAX));
+        assert_eq!(account.nonce, u64::MAX - 1);
+        assert_eq!(account.nonce_bitmap, 0);
+    }
+
+    #[test]
+    fn account_use_nonce_clears_bitmap_after_far_jump() {
+        let mut account = Account::default();
+
+        assert!(account.use_nonce(2));
+        assert!(account.use_nonce(NONCE_BITMAP_CAPACITY + 1));
+        assert_eq!(account.nonce, NONCE_BITMAP_CAPACITY + 2);
+        assert_eq!(account.nonce_bitmap, 0);
+        assert!(!account.use_nonce(NONCE_BITMAP_CAPACITY + 1));
     }
 }

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -117,65 +117,97 @@ impl core::fmt::Display for AccountKey {
 impl Span for AccountKey {}
 impl Array for AccountKey {}
 
+/// Account nonce state.
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
+#[display("Nonce {{ base: {}, bitmap: {} }}", base, bitmap)]
+pub struct Nonce {
+    /// The next nonce that has not been consumed by this account.
+    pub base: u64,
+    /// Used future nonces relative to [`Self::base`].
+    ///
+    /// Bit 0 records `base + 1`, and bit 63 records `base + 64`.
+    pub bitmap: u64,
+}
+
+impl Nonce {
+    /// Creates account nonce state from raw parts.
+    pub const fn new(base: u64, bitmap: u64) -> Self {
+        Self { base, bitmap }
+    }
+
+    /// Records a transaction nonce if it has not already been consumed.
+    ///
+    /// Nonces below [`Self::base`] are stale. Nonces inside the run-ahead
+    /// window set a bitmap bit. Nonces beyond the window clear the bitmap and
+    /// advance [`Self::base`] beyond the consumed transaction.
+    pub fn consume(&mut self, nonce: u64) -> bool {
+        let Some(next) = next_nonce_state(self.base, self.bitmap, nonce) else {
+            return false;
+        };
+
+        *self = next;
+        true
+    }
+}
+
+impl Default for Nonce {
+    fn default() -> Self {
+        Self { base: 0, bitmap: 0 }
+    }
+}
+
+impl FixedSize for Nonce {
+    const SIZE: usize = u64::SIZE + u64::SIZE;
+}
+
+impl Write for Nonce {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.base.write(buf);
+        self.bitmap.write(buf);
+    }
+}
+
+impl Read for Nonce {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &Self::Cfg) -> Result<Self, CodecError> {
+        Ok(Self {
+            base: u64::read(buf)?,
+            bitmap: u64::read(buf)?,
+        })
+    }
+}
+
 /// An account, as represented in the state of the chain.
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
-#[display(
-    "Account {{ balance: {}, nonce: {}, nonce_bitmap: {} }}",
-    balance,
-    nonce,
-    nonce_bitmap
-)]
+#[display("Account {{ balance: {}, nonce: {} }}", balance, nonce)]
 pub struct Account {
     /// The balance of the account, which is the amount of tokens that the
     /// account holds.
     pub balance: u64,
-    /// The next nonce that has not been consumed by this account.
-    pub nonce: u64,
-    /// Used future nonces relative to [`Self::nonce`].
-    ///
-    /// Bit 0 records `nonce + 1`, and bit 63 records `nonce + 64`.
-    pub nonce_bitmap: u64,
-}
-
-impl Account {
-    /// Records a transaction nonce if it has not already been consumed.
-    ///
-    /// Nonces below [`Self::nonce`] are stale. Nonces inside the run-ahead
-    /// window set a bitmap bit. Nonces beyond the window clear the bitmap and
-    /// advance [`Self::nonce`] beyond the consumed transaction.
-    pub fn use_nonce(&mut self, nonce: u64) -> bool {
-        let Some((next_nonce, next_bitmap)) =
-            next_nonce_state(self.nonce, self.nonce_bitmap, nonce)
-        else {
-            return false;
-        };
-
-        self.nonce = next_nonce;
-        self.nonce_bitmap = next_bitmap;
-        true
-    }
+    /// Consumed and run-ahead transaction nonce state.
+    pub nonce: Nonce,
 }
 
 impl Default for Account {
     fn default() -> Self {
         Self {
             balance: DEFAULT_ACCOUNT_BALANCE,
-            nonce: 0,
-            nonce_bitmap: 0,
+            nonce: Nonce::default(),
         }
     }
 }
 
 impl FixedSize for Account {
-    const SIZE: usize = u64::SIZE + u64::SIZE + u64::SIZE;
+    const SIZE: usize = u64::SIZE + Nonce::SIZE;
 }
 
 impl Write for Account {
     fn write(&self, buf: &mut impl BufMut) {
         self.balance.write(buf);
         self.nonce.write(buf);
-        self.nonce_bitmap.write(buf);
     }
 }
 
@@ -185,13 +217,12 @@ impl Read for Account {
     fn read_cfg(buf: &mut impl Buf, _: &Self::Cfg) -> Result<Self, CodecError> {
         Ok(Self {
             balance: u64::read(buf)?,
-            nonce: u64::read(buf)?,
-            nonce_bitmap: u64::read(buf)?,
+            nonce: Nonce::read(buf)?,
         })
     }
 }
 
-fn next_nonce_state(base: u64, bitmap: u64, nonce: u64) -> Option<(u64, u64)> {
+fn next_nonce_state(base: u64, bitmap: u64, nonce: u64) -> Option<Nonce> {
     let next_used_nonce = nonce.checked_add(1)?;
 
     if nonce < base {
@@ -204,7 +235,7 @@ fn next_nonce_state(base: u64, bitmap: u64, nonce: u64) -> Option<(u64, u64)> {
     }
 
     if delta > NONCE_BITMAP_CAPACITY {
-        return Some((next_used_nonce, 0));
+        return Some(Nonce::new(next_used_nonce, 0));
     }
 
     let bit = 1u64 << (delta - 1);
@@ -212,10 +243,10 @@ fn next_nonce_state(base: u64, bitmap: u64, nonce: u64) -> Option<(u64, u64)> {
         return None;
     }
 
-    Some((base, bitmap | bit))
+    Some(Nonce::new(base, bitmap | bit))
 }
 
-fn consume_current_nonce(base: u64, bitmap: u64) -> Option<(u64, u64)> {
+fn consume_current_nonce(base: u64, bitmap: u64) -> Option<Nonce> {
     let mut advance = 1;
     while advance <= NONCE_BITMAP_CAPACITY {
         let bit = 1u64 << (advance - 1);
@@ -231,7 +262,7 @@ fn consume_current_nonce(base: u64, bitmap: u64) -> Option<(u64, u64)> {
     } else {
         bitmap >> advance
     };
-    Some((nonce, bitmap))
+    Some(Nonce::new(nonce, bitmap))
 }
 
 #[cfg(test)]
@@ -279,8 +310,7 @@ mod tests {
     fn account_codec_roundtrip() {
         let account = Account {
             balance: 42,
-            nonce: 7,
-            nonce_bitmap: 3,
+            nonce: Nonce::new(7, 3),
         };
 
         let mut buf = Vec::with_capacity(Account::SIZE);
@@ -297,66 +327,55 @@ mod tests {
             Account::default(),
             Account {
                 balance: DEFAULT_ACCOUNT_BALANCE,
-                nonce: 0,
-                nonce_bitmap: 0,
+                nonce: Nonce::default(),
             }
         );
     }
 
     #[test]
-    fn account_use_nonce_records_run_ahead_nonce() {
-        let mut account = Account::default();
+    fn nonce_records_run_ahead_value() {
+        let mut nonce = Nonce::default();
 
-        assert!(account.use_nonce(2));
-        assert_eq!(account.nonce, 0);
-        assert_eq!(account.nonce_bitmap, 0b10);
+        assert!(nonce.consume(2));
+        assert_eq!(nonce, Nonce::new(0, 0b10));
     }
 
     #[test]
-    fn account_use_nonce_compacts_contiguous_run_ahead() {
-        let mut account = Account::default();
+    fn nonce_compacts_contiguous_run_ahead() {
+        let mut nonce = Nonce::default();
 
-        assert!(account.use_nonce(2));
-        assert!(account.use_nonce(0));
-        assert_eq!(account.nonce, 1);
-        assert_eq!(account.nonce_bitmap, 0b1);
+        assert!(nonce.consume(2));
+        assert!(nonce.consume(0));
+        assert_eq!(nonce, Nonce::new(1, 0b1));
 
-        assert!(account.use_nonce(1));
-        assert_eq!(account.nonce, 3);
-        assert_eq!(account.nonce_bitmap, 0);
+        assert!(nonce.consume(1));
+        assert_eq!(nonce, Nonce::new(3, 0));
     }
 
     #[test]
-    fn account_use_nonce_rejects_duplicate_run_ahead() {
-        let mut account = Account::default();
+    fn nonce_rejects_duplicate_run_ahead() {
+        let mut nonce = Nonce::default();
 
-        assert!(account.use_nonce(2));
-        assert!(!account.use_nonce(2));
-        assert_eq!(account.nonce, 0);
-        assert_eq!(account.nonce_bitmap, 0b10);
+        assert!(nonce.consume(2));
+        assert!(!nonce.consume(2));
+        assert_eq!(nonce, Nonce::new(0, 0b10));
     }
 
     #[test]
-    fn account_use_nonce_rejects_run_ahead_nonce_that_cannot_advance() {
-        let mut account = Account {
-            balance: 0,
-            nonce: u64::MAX - 1,
-            nonce_bitmap: 0,
-        };
+    fn nonce_rejects_run_ahead_value_that_cannot_advance() {
+        let mut nonce = Nonce::new(u64::MAX - 1, 0);
 
-        assert!(!account.use_nonce(u64::MAX));
-        assert_eq!(account.nonce, u64::MAX - 1);
-        assert_eq!(account.nonce_bitmap, 0);
+        assert!(!nonce.consume(u64::MAX));
+        assert_eq!(nonce, Nonce::new(u64::MAX - 1, 0));
     }
 
     #[test]
-    fn account_use_nonce_clears_bitmap_after_far_jump() {
-        let mut account = Account::default();
+    fn nonce_clears_bitmap_after_far_jump() {
+        let mut nonce = Nonce::default();
 
-        assert!(account.use_nonce(2));
-        assert!(account.use_nonce(NONCE_BITMAP_CAPACITY + 1));
-        assert_eq!(account.nonce, NONCE_BITMAP_CAPACITY + 2);
-        assert_eq!(account.nonce_bitmap, 0);
-        assert!(!account.use_nonce(NONCE_BITMAP_CAPACITY + 1));
+        assert!(nonce.consume(2));
+        assert!(nonce.consume(NONCE_BITMAP_CAPACITY + 1));
+        assert_eq!(nonce, Nonce::new(NONCE_BITMAP_CAPACITY + 2, 0));
+        assert!(!nonce.consume(NONCE_BITMAP_CAPACITY + 1));
     }
 }

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -118,7 +118,7 @@ impl Span for AccountKey {}
 impl Array for AccountKey {}
 
 /// Account nonce state.
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Display, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(any(feature = "arbitrary", test), derive(arbitrary::Arbitrary))]
 #[display("Nonce {{ base: {}, bitmap: {} }}", base, bitmap)]
 pub struct Nonce {
@@ -148,12 +148,6 @@ impl Nonce {
 
         *self = next;
         true
-    }
-}
-
-impl Default for Nonce {
-    fn default() -> Self {
-        Self { base: 0, bitmap: 0 }
     }
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -11,7 +11,7 @@ pub use signed::{
 };
 
 mod account;
-pub use account::{Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY};
+pub use account::{Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY, Nonce};
 
 mod auth;
 pub use auth::{TransactionBatchVerifier, TransactionPublicKey, TransactionSignature};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -11,7 +11,7 @@ pub use signed::{
 };
 
 mod account;
-pub use account::{Account, AccountKey, DEFAULT_ACCOUNT_BALANCE};
+pub use account::{Account, AccountKey, DEFAULT_ACCOUNT_BALANCE, NONCE_BITMAP_CAPACITY};
 
 mod auth;
 pub use auth::{TransactionBatchVerifier, TransactionPublicKey, TransactionSignature};

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -34,6 +34,14 @@ import {
     type VerifiedAccountProof,
     type VerifiedTransactionProof,
 } from './qmdb';
+import {
+    consumeNonce,
+    emptyNonceState,
+    mergeNonceStates,
+    nextAvailableNonce,
+    nonceStatesEqual,
+    type NonceState,
+} from './nonce';
 import { isRetryableAccountProofError, isRetryableProofError } from './proofRetry';
 import {
     clearSession,
@@ -69,7 +77,6 @@ const DEFAULT_SQL_URL = 'http://127.0.0.1:8091';
 const DEFAULT_QMDB_URL = 'http://127.0.0.1:8092';
 const DEFAULT_STORE_URL = 'http://127.0.0.1:8090';
 const DEFAULT_MEMPOOL_URL = 'http://127.0.0.1:8080';
-const MAX_U64 = (1n << 64n) - 1n;
 
 const indexerUrl = import.meta.env.VITE_SQL_URL ?? DEFAULT_SQL_URL;
 const qmdbUrl = import.meta.env.VITE_QMDB_URL ?? DEFAULT_QMDB_URL;
@@ -191,7 +198,7 @@ export default function App() {
     const [accountNextCursor, setAccountNextCursor] = useState<Uint8Array | null>(null);
     const [searchMessage, setSearchMessage] = useState('');
     const [copyToast, setCopyToast] = useState('');
-    const nextNonceRef = useRef(0n);
+    const nextNonceRef = useRef<NonceState>(emptyNonceState());
     const pendingBlocksRef = useRef<ObservedBlock[]>([]);
     const blockFlushTimeoutRef = useRef<number | null>(null);
     const copyToastTimeoutRef = useRef<number | null>(null);
@@ -214,17 +221,13 @@ export default function App() {
     );
     const currentAccountCursor = accountCursorStack[accountCursorStack.length - 1] ?? null;
 
-    const setLocalNonce = (nextNonce: bigint) => {
+    const setLocalNonceState = (nextNonce: NonceState) => {
         nextNonceRef.current = nextNonce;
-        setNonce(nextNonce.toString());
+        setNonce(nextAvailableNonce(nextNonce).toString());
     };
 
-    const advanceLocalNonceAtLeast = (nextNonce: bigint) => {
-        if (nextNonce > nextNonceRef.current) {
-            setLocalNonce(nextNonce);
-            return;
-        }
-        setNonce(nextNonceRef.current.toString());
+    const mergeLocalNonceState = (nextNonce: NonceState) => {
+        setLocalNonceState(mergeNonceStates(nextNonceRef.current, nextNonce));
     };
 
     const queueObservedBlocks = (nextBlocks: readonly ObservedBlock[]) => {
@@ -533,7 +536,7 @@ export default function App() {
     useEffect(() => {
         if (!wallet) {
             setAccount(null);
-            setLocalNonce(0n);
+            setLocalNonceState(emptyNonceState());
             setAccountMessage('account metadata unavailable');
             return;
         }
@@ -545,7 +548,7 @@ export default function App() {
             .then((nextAccount) => {
                 if (cancelled) return;
                 setAccount(nextAccount);
-                advanceLocalNonceAtLeast(BigInt(nextAccount?.nonce ?? 0));
+                mergeLocalNonceState(accountNonceState(nextAccount));
                 setAccountMessage(
                     nextAccount
                         ? 'committed account loaded'
@@ -569,7 +572,7 @@ export default function App() {
         try {
             const nextAccount = await fetchAccount(mempoolUrl, wallet.publicKeyHex);
             setAccount(nextAccount);
-            advanceLocalNonceAtLeast(BigInt(nextAccount?.nonce ?? 0));
+            mergeLocalNonceState(accountNonceState(nextAccount));
             setAccountMessage(
                 nextAccount ? 'committed account loaded' : 'no committed account yet; default balance applies',
             );
@@ -690,17 +693,18 @@ export default function App() {
 
         setPendingSubmissionCount((count) => count + 1);
         setSubmitMessage('forming transaction');
-        let reservedNonce: bigint | null = null;
+        let reservation: { previous: NonceState; next: NonceState } | null = null;
         try {
             const parsedToKey = parseAccountKeyHex(toKey);
             const parsedValue = parseU64(value, 'value');
-            const parsedNonce = nextNonceRef.current;
-            const nextNonce = parsedNonce + 1n;
-            if (nextNonce > MAX_U64) {
+            const previousNonce = nextNonceRef.current;
+            const parsedNonce = nextAvailableNonce(previousNonce);
+            const nextNonce = consumeNonce(previousNonce, parsedNonce);
+            if (nextNonce === null) {
                 throw new Error('nonce must fit in u64');
             }
-            setLocalNonce(nextNonce);
-            reservedNonce = parsedNonce;
+            setLocalNonceState(nextNonce);
+            reservation = { previous: previousNonce, next: nextNonce };
 
             const encoded = await encodeSignedTransaction(
                 {
@@ -741,8 +745,8 @@ export default function App() {
             setSubmitMessage('');
             await refreshAccount();
         } catch (error) {
-            if (reservedNonce !== null && nextNonceRef.current === reservedNonce + 1n) {
-                setLocalNonce(reservedNonce);
+            if (reservation !== null && nonceStatesEqual(nextNonceRef.current, reservation.next)) {
+                setLocalNonceState(reservation.previous);
             }
             setSubmitMessage(error instanceof Error ? error.message : String(error));
         } finally {
@@ -1711,6 +1715,17 @@ function normalizeAccountInput(value: string): string | null {
         return normalized;
     }
     return null;
+}
+
+function accountNonceState(account: AccountView | null): NonceState {
+    if (account === null) {
+        return emptyNonceState();
+    }
+
+    return {
+        base: BigInt(account.nonce.base),
+        bitmap: BigInt(account.nonce.bitmap),
+    };
 }
 
 function accountFromLocation(): string {

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -879,7 +879,14 @@ function AccountPage({
             <div className="account-proof-grid">
                 <ProofDatum label="cert" value={target ? `h${target.height.toString()} / v${target.view.toString()}` : proof.detail} />
                 <ProofDatum label="block" value={target ? shortHex(bytesToHex(target.blockDigest)) : '-'} />
-                <ProofDatum label="state" value={proof.status === 'verified' ? `${proof.balance.toString()} / nonce ${proof.nonce.toString()}` : proof.detail} />
+                <ProofDatum
+                    label="state"
+                    value={
+                        proof.status === 'verified'
+                            ? `${proof.balance.toString()} / nonce ${proof.nonce.toString()} / bitmap ${proof.nonceBitmap.toString()}`
+                            : proof.detail
+                    }
+                />
                 <ProofDatum label="state proof" value={proof.status === 'verified' ? `loc ${proof.location.toString()} / ${proof.proofSizeBytes}b` : proof.status} />
             </div>
             <div className="account-page__subhead">
@@ -1116,6 +1123,7 @@ function WalletPanel({
     onSubmit: () => void;
 }) {
     const balance = account?.balance ?? 100;
+    const nonceBitmap = account?.nonce_bitmap ?? 0;
     const isWalletLoading = walletMessage === 'opening passkey prompt';
     const isAccountLoading = accountMessage === 'loading account metadata';
 
@@ -1163,6 +1171,10 @@ function WalletPanel({
                 <div className="wallet__cell">
                     <span>nonce</span>
                     <strong>{nonce}</strong>
+                </div>
+                <div className="wallet__cell">
+                    <span>nonce bitmap</span>
+                    <strong>{nonceBitmap.toLocaleString()}</strong>
                 </div>
             </div>
             <form

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -42,7 +42,11 @@ import {
     nonceStatesEqual,
     type NonceState,
 } from './nonce';
-import { isRetryableAccountProofError, isRetryableProofError } from './proofRetry';
+import {
+    isMissingAccountProofError,
+    isRetryableAccountProofError,
+    isRetryableProofError,
+} from './proofRetry';
 import {
     clearSession,
     createWallet,
@@ -142,6 +146,7 @@ type TransactionProofState =
 type AccountProofState =
     | { readonly status: 'waiting'; readonly detail: string }
     | { readonly status: 'fetching'; readonly detail: string }
+    | { readonly status: 'missing'; readonly detail: string }
     | ({
           readonly status: 'verified';
           readonly detail: string;
@@ -355,17 +360,30 @@ export default function App() {
                 simplexVerificationMaterial,
                 signal: controller.signal,
             });
-            const proof = await fetchAndVerifyAccountProof({
-                qmdbUrl,
-                sqlUrl: indexerUrl,
-                account: lookupAccount,
-                target,
-                signal: controller.signal,
-            });
-            return { target, proof };
+            try {
+                const proof = await fetchAndVerifyAccountProof({
+                    qmdbUrl,
+                    sqlUrl: indexerUrl,
+                    account: lookupAccount,
+                    target,
+                    signal: controller.signal,
+                });
+                return { target, proof };
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
+                if (isMissingAccountProofError(detail)) {
+                    return { target, proof: null };
+                }
+                throw error;
+            }
         }, controller.signal)
             .then(({ target, proof }) => {
                 if (controller.signal.aborted) return;
+                if (proof === null) {
+                    setAccountProof({ status: 'missing', detail: 'not yet exists' });
+                    setAccountTarget(target);
+                    return;
+                }
                 setAccountProof({
                     status: 'verified',
                     detail: `verified at height ${target.height.toString()}`,
@@ -633,20 +651,28 @@ export default function App() {
         }
     };
 
-    const submitAccountLookup = () => {
-        const normalized = normalizeAccountInput(accountInput);
-        if (!normalized) {
-            setSearchMessage('expected a 32-byte address');
-            return;
-        }
+    const openAccountPage = (value: string): boolean => {
+        const normalized = normalizeAccountInput(value);
+        if (!normalized) return false;
+
         setSearchMessage('');
         setLookupAccount(normalized);
         setAccountInput(normalized);
         setAccountCursorStack([null]);
         const url = new URL(window.location.href);
         url.searchParams.set('account', normalized);
-        window.history.pushState(null, '', `${url.pathname}${url.search}${url.hash}`);
+        const nextLocation = `${url.pathname}${url.search}${url.hash}`;
+        if (nextLocation !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+            window.history.pushState(null, '', nextLocation);
+        }
+        setIsWalletOpen(false);
         setIsSearchOpen(false);
+        return true;
+    };
+
+    const submitAccountLookup = () => {
+        if (openAccountPage(accountInput)) return;
+        setSearchMessage('expected a 32-byte address');
     };
 
     const clearAccountLookup = () => {
@@ -790,6 +816,7 @@ export default function App() {
                             <AccountPage
                                 account={lookupAccount}
                                 onCopy={copyValue}
+                                onOpenAddress={openAccountPage}
                                 pageNumber={accountCursorStack.length}
                                 proof={accountProof}
                                 target={accountTarget}
@@ -845,6 +872,7 @@ export default function App() {
                             transactions={history}
                             signedInAccountKey={signedInAccountKey}
                             onCopy={copyValue}
+                            onOpenAddress={openAccountPage}
                             verifyCertificates={verifyCertificates}
                         />
                     </WalletModal>
@@ -871,6 +899,7 @@ export default function App() {
 function AccountPage({
     account,
     onCopy,
+    onOpenAddress,
     pageNumber,
     proof,
     target,
@@ -885,6 +914,7 @@ function AccountPage({
 }: {
     account: string;
     onCopy: (value: string) => void;
+    onOpenAddress: (value: string) => void;
     pageNumber: number;
     proof: AccountProofState;
     target: LatestProofTarget | null;
@@ -917,7 +947,16 @@ function AccountPage({
                             : proof.detail
                     }
                 />
-                <ProofDatum label="state proof" value={proof.status === 'verified' ? `loc ${proof.location.toString()} / ${proof.proofSizeBytes}b` : proof.status} />
+                <ProofDatum
+                    label="state proof"
+                    value={
+                        proof.status === 'verified'
+                            ? `loc ${proof.location.toString()} / ${proof.proofSizeBytes}b`
+                            : proof.status === 'missing'
+                                ? proof.detail
+                                : proof.status
+                    }
+                />
             </div>
             <div className="account-page__subhead">
                 <span>{activityMode} tx page {pageNumber}</span>
@@ -953,14 +992,18 @@ function AccountPage({
                             <span className="account-tx-row__height">h{row.height.toString()}:{row.blockIndex}</span>
                             <CopyableValue value={row.digest} onCopy={onCopy} />
                             <span>from</span>
-                            <CopyableValue
+                            <AccountPageAddressValue
+                                account={account}
                                 value={row.direction === 'sent' ? account : row.counterparty}
                                 onCopy={onCopy}
+                                onOpenAddress={onOpenAddress}
                             />
                             <span>to</span>
-                            <CopyableValue
+                            <AccountPageAddressValue
+                                account={account}
                                 value={row.direction === 'sent' ? row.counterparty : account}
                                 onCopy={onCopy}
+                                onOpenAddress={onOpenAddress}
                             />
                         </div>
                         <div className="account-tx-row__meta">
@@ -1155,6 +1198,7 @@ function WalletPanel({
     const balance = account?.balance ?? 100;
     const isWalletLoading = walletMessage === 'opening passkey prompt';
     const isAccountLoading = accountMessage === 'loading account metadata';
+    const walletAccountDisplay = walletAccountKey?.toLowerCase() ?? 'not authenticated';
 
     return (
         <section className="wallet">
@@ -1185,11 +1229,11 @@ function WalletPanel({
             </div>
             <div className="wallet__grid">
                 <div className="wallet__cell">
-                    <span>account</span>
+                    <span>address</span>
                     <CopyableValue
                         disabled={!walletAccountKey}
                         plain
-                        value={walletAccountKey ?? 'not authenticated'}
+                        value={walletAccountDisplay}
                         onCopy={onCopy}
                     />
                 </div>
@@ -1245,36 +1289,22 @@ function WalletPanel({
 
 function CopyableValue({
     disabled = false,
-    flashOnCopy = true,
     plain = false,
     value,
     onCopy,
 }: {
     disabled?: boolean;
-    flashOnCopy?: boolean;
     plain?: boolean;
     value: string;
     onCopy: (value: string) => void;
 }) {
-    const [flashing, setFlashing] = useState(false);
-    const flashTimeoutRef = useRef<number | null>(null);
-
     const handleClick = () => {
         onCopy(value);
-        if (!flashOnCopy) return;
-        if (flashTimeoutRef.current !== null) clearTimeout(flashTimeoutRef.current);
-        setFlashing(true);
-        flashTimeoutRef.current = window.setTimeout(() => {
-            setFlashing(false);
-            flashTimeoutRef.current = null;
-        }, 800);
     };
 
-    const isCopied = flashing;
     const className = [
         'copyable',
         plain ? 'copyable--plain' : '',
-        isCopied ? 'is-copied' : '',
     ]
         .filter(Boolean)
         .join(' ');
@@ -1289,6 +1319,56 @@ function CopyableValue({
             <span className="copyable__value">{value}</span>
         </button>
     );
+}
+
+function AddressValue({
+    disabled = false,
+    plain = false,
+    value,
+    onOpenAddress,
+}: {
+    disabled?: boolean;
+    plain?: boolean;
+    value: string;
+    onOpenAddress: (value: string) => void;
+}) {
+    const className = [
+        'copyable',
+        'copyable--address',
+        plain ? 'copyable--plain' : '',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            aria-label={`open address ${value}`}
+            className={className}
+            disabled={disabled}
+            onClick={() => onOpenAddress(value)}
+            title="open address"
+            type="button"
+        >
+            <span className="copyable__value">{value}</span>
+        </button>
+    );
+}
+
+function AccountPageAddressValue({
+    account,
+    value,
+    onCopy,
+    onOpenAddress,
+}: {
+    account: string;
+    value: string;
+    onCopy: (value: string) => void;
+    onOpenAddress: (value: string) => void;
+}) {
+    if (normalizeAccountInput(value) === account) {
+        return <CopyableValue value={value} onCopy={onCopy} />;
+    }
+    return <AddressValue value={value} onOpenAddress={onOpenAddress} />;
 }
 
 function TerminalToast({ message }: { message: string }) {
@@ -1324,11 +1404,13 @@ function TransactionHistory({
     transactions,
     signedInAccountKey,
     onCopy,
+    onOpenAddress,
     verifyCertificates,
 }: {
     transactions: SubmittedTransaction[];
     signedInAccountKey: string | null;
     onCopy: (value: string) => void;
+    onOpenAddress: (value: string) => void;
     verifyCertificates: boolean;
 }) {
     const formatter = useMemo(
@@ -1354,6 +1436,7 @@ function TransactionHistory({
                         key={tx.digest}
                         formatter={formatter}
                         onCopy={onCopy}
+                        onOpenAddress={onOpenAddress}
                         signedInAccountKey={signedInAccountKey}
                         tx={tx}
                         verifyCertificates={verifyCertificates}
@@ -1367,12 +1450,14 @@ function TransactionHistory({
 function TransactionRecord({
     formatter,
     onCopy,
+    onOpenAddress,
     signedInAccountKey,
     tx,
     verifyCertificates,
 }: {
     formatter: Intl.DateTimeFormat;
     onCopy: (value: string) => void;
+    onOpenAddress: (value: string) => void;
     signedInAccountKey: string | null;
     tx: SubmittedTransaction;
     verifyCertificates: boolean;
@@ -1384,10 +1469,16 @@ function TransactionRecord({
                 <span className="tx-record__label">tx</span>
                 <CopyableValue value={tx.digest} onCopy={onCopy} />
                 <span className="tx-record__label">from</span>
-                <CopyableValue value={tx.sender} onCopy={onCopy} />
+                <AddressValue
+                    value={tx.sender}
+                    onOpenAddress={onOpenAddress}
+                />
                 <span className="tx-record__arrow" aria-hidden="true">→</span>
                 <span className="tx-record__label">to</span>
-                <CopyableValue value={tx.to} onCopy={onCopy} />
+                <AddressValue
+                    value={tx.to}
+                    onOpenAddress={onOpenAddress}
+                />
                 <span className="tx-record__nonce">value {tx.value}</span>
                 <span className="tx-record__nonce">nonce {tx.nonce}</span>
                 <span className="tx-record__time">{formatter.format(tx.submittedAt)}</span>

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -69,6 +69,7 @@ const DEFAULT_SQL_URL = 'http://127.0.0.1:8091';
 const DEFAULT_QMDB_URL = 'http://127.0.0.1:8092';
 const DEFAULT_STORE_URL = 'http://127.0.0.1:8090';
 const DEFAULT_MEMPOOL_URL = 'http://127.0.0.1:8080';
+const MAX_U64 = (1n << 64n) - 1n;
 
 const indexerUrl = import.meta.env.VITE_SQL_URL ?? DEFAULT_SQL_URL;
 const qmdbUrl = import.meta.env.VITE_QMDB_URL ?? DEFAULT_QMDB_URL;
@@ -173,7 +174,7 @@ export default function App() {
     const [value, setValue] = useState('1');
     const [nonce, setNonce] = useState('0');
     const [submitMessage, setSubmitMessage] = useState('');
-    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pendingSubmissionCount, setPendingSubmissionCount] = useState(0);
     const [history, setHistory] = useState<SubmittedTransaction[]>([]);
     const [loadedHistoryKey, setLoadedHistoryKey] = useState<string | null>(null);
     const [lookupAccount, setLookupAccount] = useState(() => accountFromLocation());
@@ -190,9 +191,11 @@ export default function App() {
     const [accountNextCursor, setAccountNextCursor] = useState<Uint8Array | null>(null);
     const [searchMessage, setSearchMessage] = useState('');
     const [copyToast, setCopyToast] = useState('');
+    const nextNonceRef = useRef(0n);
     const pendingBlocksRef = useRef<ObservedBlock[]>([]);
     const blockFlushTimeoutRef = useRef<number | null>(null);
     const copyToastTimeoutRef = useRef<number | null>(null);
+    const isSubmitting = pendingSubmissionCount > 0;
     const isWalletBusy =
         walletMessage === 'opening passkey prompt' ||
         accountMessage === 'loading account metadata' ||
@@ -210,6 +213,19 @@ export default function App() {
         signedInAccountKey,
     );
     const currentAccountCursor = accountCursorStack[accountCursorStack.length - 1] ?? null;
+
+    const setLocalNonce = (nextNonce: bigint) => {
+        nextNonceRef.current = nextNonce;
+        setNonce(nextNonce.toString());
+    };
+
+    const advanceLocalNonceAtLeast = (nextNonce: bigint) => {
+        if (nextNonce > nextNonceRef.current) {
+            setLocalNonce(nextNonce);
+            return;
+        }
+        setNonce(nextNonceRef.current.toString());
+    };
 
     const queueObservedBlocks = (nextBlocks: readonly ObservedBlock[]) => {
         if (nextBlocks.length === 0) return;
@@ -517,6 +533,7 @@ export default function App() {
     useEffect(() => {
         if (!wallet) {
             setAccount(null);
+            setLocalNonce(0n);
             setAccountMessage('account metadata unavailable');
             return;
         }
@@ -528,8 +545,7 @@ export default function App() {
             .then((nextAccount) => {
                 if (cancelled) return;
                 setAccount(nextAccount);
-                const nextNonce = nextAccount?.nonce ?? 0;
-                setNonce(String(nextNonce));
+                advanceLocalNonceAtLeast(BigInt(nextAccount?.nonce ?? 0));
                 setAccountMessage(
                     nextAccount
                         ? 'committed account loaded'
@@ -553,7 +569,7 @@ export default function App() {
         try {
             const nextAccount = await fetchAccount(mempoolUrl, wallet.publicKeyHex);
             setAccount(nextAccount);
-            setNonce(String(nextAccount?.nonce ?? 0));
+            advanceLocalNonceAtLeast(BigInt(nextAccount?.nonce ?? 0));
             setAccountMessage(
                 nextAccount ? 'committed account loaded' : 'no committed account yet; default balance applies',
             );
@@ -666,18 +682,26 @@ export default function App() {
     };
 
     const submitTransfer = async () => {
-        if (!wallet || isSubmitting) return;
+        if (!wallet) return;
         if (!walletAccountKey) {
             setSubmitMessage('loading account address');
             return;
         }
 
-        setIsSubmitting(true);
+        setPendingSubmissionCount((count) => count + 1);
         setSubmitMessage('forming transaction');
+        let reservedNonce: bigint | null = null;
         try {
             const parsedToKey = parseAccountKeyHex(toKey);
             const parsedValue = parseU64(value, 'value');
-            const parsedNonce = parseU64(nonce, 'nonce');
+            const parsedNonce = nextNonceRef.current;
+            const nextNonce = parsedNonce + 1n;
+            if (nextNonce > MAX_U64) {
+                throw new Error('nonce must fit in u64');
+            }
+            setLocalNonce(nextNonce);
+            reservedNonce = parsedNonce;
+
             const encoded = await encodeSignedTransaction(
                 {
                     senderPublicKey: wallet.publicKey,
@@ -717,10 +741,12 @@ export default function App() {
             setSubmitMessage('');
             await refreshAccount();
         } catch (error) {
+            if (reservedNonce !== null && nextNonceRef.current === reservedNonce + 1n) {
+                setLocalNonce(reservedNonce);
+            }
             setSubmitMessage(error instanceof Error ? error.message : String(error));
         } finally {
-            setSubmitMessage('');
-            setIsSubmitting(false);
+            setPendingSubmissionCount((count) => Math.max(0, count - 1));
         }
     };
 
@@ -1191,7 +1217,7 @@ function WalletPanel({
                         onChange={(event) => onToKeyChange(event.target.value)}
                         placeholder="Recipient address"
                         spellCheck={false}
-                        disabled={!wallet || isSubmitting}
+                        disabled={!wallet}
                     />
                 </label>
                 <label>
@@ -1200,10 +1226,10 @@ function WalletPanel({
                         value={value}
                         onChange={(event) => onValueChange(event.target.value)}
                         inputMode="numeric"
-                        disabled={!wallet || isSubmitting}
+                        disabled={!wallet}
                     />
                 </label>
-                <button className="transfer__submit" disabled={!wallet || isSubmitting} type="submit">
+                <button className="transfer__submit" disabled={!wallet} type="submit">
                     submit
                 </button>
             </form>

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -909,7 +909,7 @@ function AccountPage({
                     label="state"
                     value={
                         proof.status === 'verified'
-                            ? `${proof.balance.toString()} / nonce ${proof.nonce.toString()} / bitmap ${proof.nonceBitmap.toString()}`
+                            ? `${proof.balance.toString()} / nonce ${proof.nonce.toString()}`
                             : proof.detail
                     }
                 />
@@ -1149,7 +1149,6 @@ function WalletPanel({
     onSubmit: () => void;
 }) {
     const balance = account?.balance ?? 100;
-    const nonceBitmap = account?.nonce_bitmap ?? 0;
     const isWalletLoading = walletMessage === 'opening passkey prompt';
     const isAccountLoading = accountMessage === 'loading account metadata';
 
@@ -1197,10 +1196,6 @@ function WalletPanel({
                 <div className="wallet__cell">
                     <span>nonce</span>
                     <strong>{nonce}</strong>
-                </div>
-                <div className="wallet__cell">
-                    <span>nonce bitmap</span>
-                    <strong>{nonceBitmap.toLocaleString()}</strong>
                 </div>
             </div>
             <form

--- a/explorer/src/mempool.ts
+++ b/explorer/src/mempool.ts
@@ -2,8 +2,12 @@ import { toArrayBuffer } from './codec';
 
 export interface AccountView {
     readonly balance: number;
-    readonly nonce: number;
-    readonly nonce_bitmap: number;
+    readonly nonce: AccountNonceView;
+}
+
+export interface AccountNonceView {
+    readonly base: number;
+    readonly bitmap: number;
 }
 
 export type TxStatus =

--- a/explorer/src/mempool.ts
+++ b/explorer/src/mempool.ts
@@ -2,10 +2,10 @@ import { toArrayBuffer } from './codec';
 
 export interface AccountView {
     readonly balance: number;
-    readonly nonce: AccountNonceView;
+    readonly nonce: NonceView;
 }
 
-export interface AccountNonceView {
+export interface NonceView {
     readonly base: number;
     readonly bitmap: number;
 }

--- a/explorer/src/mempool.ts
+++ b/explorer/src/mempool.ts
@@ -3,6 +3,7 @@ import { toArrayBuffer } from './codec';
 export interface AccountView {
     readonly balance: number;
     readonly nonce: number;
+    readonly nonce_bitmap: number;
 }
 
 export type TxStatus =

--- a/explorer/src/nonce.ts
+++ b/explorer/src/nonce.ts
@@ -1,0 +1,97 @@
+const NONCE_BITMAP_CAPACITY = 64n;
+const MAX_U64 = (1n << 64n) - 1n;
+
+export interface NonceState {
+    readonly base: bigint;
+    readonly bitmap: bigint;
+}
+
+export function emptyNonceState(): NonceState {
+    return { base: 0n, bitmap: 0n };
+}
+
+export function nextAvailableNonce(state: NonceState): bigint {
+    return state.base;
+}
+
+export function consumeNonce(state: NonceState, nonce: bigint): NonceState | null {
+    if (nonce < state.base) {
+        return null;
+    }
+    if (nonce > MAX_U64) {
+        return null;
+    }
+
+    const nextUsedNonce = nonce + 1n;
+    if (nextUsedNonce > MAX_U64) {
+        return null;
+    }
+
+    const delta = nonce - state.base;
+    if (delta === 0n) {
+        return consumeBaseNonce(state);
+    }
+
+    if (delta > NONCE_BITMAP_CAPACITY) {
+        return { base: nextUsedNonce, bitmap: 0n };
+    }
+
+    const bit = 1n << (delta - 1n);
+    if ((state.bitmap & bit) !== 0n) {
+        return null;
+    }
+
+    return { base: state.base, bitmap: state.bitmap | bit };
+}
+
+export function mergeNonceStates(left: NonceState, right: NonceState): NonceState {
+    let merged = left.base > right.base
+        ? { base: left.base, bitmap: 0n }
+        : { base: right.base, bitmap: 0n };
+
+    for (const nonce of consumedBitmapNonces(left, merged.base)) {
+        merged = consumeNonce(merged, nonce) ?? merged;
+    }
+    for (const nonce of consumedBitmapNonces(right, merged.base)) {
+        merged = consumeNonce(merged, nonce) ?? merged;
+    }
+
+    return merged;
+}
+
+export function nonceStatesEqual(left: NonceState, right: NonceState): boolean {
+    return left.base === right.base && left.bitmap === right.bitmap;
+}
+
+function consumeBaseNonce(state: NonceState): NonceState | null {
+    let advance = 1n;
+    while (advance <= NONCE_BITMAP_CAPACITY) {
+        const bit = 1n << (advance - 1n);
+        if ((state.bitmap & bit) === 0n) {
+            break;
+        }
+        advance += 1n;
+    }
+
+    const base = state.base + advance;
+    if (base > MAX_U64) {
+        return null;
+    }
+
+    const bitmap = advance >= NONCE_BITMAP_CAPACITY ? 0n : state.bitmap >> advance;
+    return { base, bitmap };
+}
+
+function* consumedBitmapNonces(state: NonceState, base: bigint): Iterable<bigint> {
+    for (let offset = 0n; offset < NONCE_BITMAP_CAPACITY; offset += 1n) {
+        const bit = 1n << offset;
+        if ((state.bitmap & bit) === 0n) {
+            continue;
+        }
+
+        const nonce = state.base + offset + 1n;
+        if (nonce >= base) {
+            yield nonce;
+        }
+    }
+}

--- a/explorer/src/proofRetry.ts
+++ b/explorer/src/proofRetry.ts
@@ -5,12 +5,19 @@ export function isRetryableProofError(detail: string): boolean {
     return RETRYABLE_PROOF_ERROR.test(detail);
 }
 
+export function isMissingAccountProofError(detail: string): boolean {
+    return /^account .+ is not indexed$/.test(detail);
+}
+
 export function isRetryableAccountProofError(detail: string): boolean {
     return (
-        detail.includes('outside finalized state range') ||
-        detail.includes('[out_of_range]') ||
-        detail.includes('[unavailable]') ||
-        detail.includes('QMDB') ||
-        detail.includes('missing')
+        !isMissingAccountProofError(detail) &&
+        (
+            detail.includes('outside finalized state range') ||
+            detail.includes('[out_of_range]') ||
+            detail.includes('[unavailable]') ||
+            detail.includes('QMDB') ||
+            detail.includes('missing')
+        )
     );
 }

--- a/explorer/src/qmdb.ts
+++ b/explorer/src/qmdb.ts
@@ -30,7 +30,7 @@ const TRANSACTION_VALUE_BYTES = 8;
 const TRANSACTION_NONCE_BYTES = 8;
 const TRANSACTION_BODY_BYTES =
     TRANSACTION_PUBLIC_KEY_BYTES + ACCOUNT_KEY_BYTES + TRANSACTION_VALUE_BYTES + TRANSACTION_NONCE_BYTES;
-const ACCOUNT_VALUE_BYTES = 16;
+const ACCOUNT_VALUE_BYTES = 24;
 const ACCOUNT_CURSOR_BYTES = 24;
 
 const TX_META_TABLE = 'tx_meta';
@@ -54,6 +54,7 @@ const ACCOUNT_META_TABLE = 'account_meta';
 const ACCOUNT_META_ACCOUNT = 'account';
 const ACCOUNT_META_BALANCE = 'balance';
 const ACCOUNT_META_NONCE = 'nonce';
+const ACCOUNT_META_NONCE_BITMAP = 'nonce_bitmap';
 const ACCOUNT_META_QMDB_LOCATION = 'qmdb_location';
 
 export interface VerifiedTransactionProof {
@@ -107,6 +108,7 @@ export interface AccountTransactionPage {
 export interface VerifiedAccountProof {
     readonly balance: bigint;
     readonly nonce: bigint;
+    readonly nonceBitmap: bigint;
     readonly location: bigint;
     readonly tip: bigint;
     readonly proofSizeBytes: number;
@@ -232,13 +234,18 @@ export async function fetchAndVerifyAccountProof({
     );
     const accountValue = decodeAccountValue(verification.value);
 
-    if (accountValue.balance !== row.balance || accountValue.nonce !== row.nonce) {
+    if (
+        accountValue.balance !== row.balance ||
+        accountValue.nonce !== row.nonce ||
+        accountValue.nonceBitmap !== row.nonceBitmap
+    ) {
         throw new Error('account proof value does not match account index row');
     }
 
     return {
         balance: accountValue.balance,
         nonce: accountValue.nonce,
+        nonceBitmap: accountValue.nonceBitmap,
         location: row.location,
         tip,
         proofSizeBytes: verification.proofSizeBytes,
@@ -669,7 +676,11 @@ async function fetchAccountProofRow(
     const result = await sqlQuery(
         sqlUrl,
         `
-            SELECT ${ACCOUNT_META_BALANCE}, ${ACCOUNT_META_NONCE}, ${ACCOUNT_META_QMDB_LOCATION}
+            SELECT
+                ${ACCOUNT_META_BALANCE},
+                ${ACCOUNT_META_NONCE},
+                ${ACCOUNT_META_NONCE_BITMAP},
+                ${ACCOUNT_META_QMDB_LOCATION}
             FROM ${ACCOUNT_META_TABLE}
             WHERE ${ACCOUNT_META_ACCOUNT} = ${fixedBinaryLiteral(account)}
             LIMIT 1
@@ -683,6 +694,10 @@ async function fetchAccountProofRow(
     return {
         balance: expectBigint(row.values[ACCOUNT_META_BALANCE], ACCOUNT_META_BALANCE),
         nonce: expectBigint(row.values[ACCOUNT_META_NONCE], ACCOUNT_META_NONCE),
+        nonceBitmap: expectBigint(
+            row.values[ACCOUNT_META_NONCE_BITMAP],
+            ACCOUNT_META_NONCE_BITMAP,
+        ),
         location: expectBigint(row.values[ACCOUNT_META_QMDB_LOCATION], ACCOUNT_META_QMDB_LOCATION),
     };
 }
@@ -790,13 +805,16 @@ function assertByteLength(bytes: Uint8Array, length: number, field: string) {
     }
 }
 
-function decodeAccountValue(value: Uint8Array): Pick<AccountProofRow, 'balance' | 'nonce'> {
+function decodeAccountValue(
+    value: Uint8Array,
+): Pick<AccountProofRow, 'balance' | 'nonce' | 'nonceBitmap'> {
     if (value.length !== ACCOUNT_VALUE_BYTES) {
         throw new Error('malformed account proof value');
     }
     return {
         balance: readU64Be(value, 0),
         nonce: readU64Be(value, 8),
+        nonceBitmap: readU64Be(value, 16),
     };
 }
 
@@ -843,5 +861,6 @@ function trimTrailingSlash(value: string): string {
 interface AccountProofRow {
     readonly balance: bigint;
     readonly nonce: bigint;
+    readonly nonceBitmap: bigint;
     readonly location: bigint;
 }

--- a/explorer/src/qmdb.ts
+++ b/explorer/src/qmdb.ts
@@ -53,7 +53,7 @@ const TX_ACTIVITY_ROLE_RECEIVER = 1n;
 const ACCOUNT_META_TABLE = 'account_meta';
 const ACCOUNT_META_ACCOUNT = 'account';
 const ACCOUNT_META_BALANCE = 'balance';
-const ACCOUNT_META_NONCE = 'nonce';
+const ACCOUNT_META_NONCE_BASE = 'nonce_base';
 const ACCOUNT_META_NONCE_BITMAP = 'nonce_bitmap';
 const ACCOUNT_META_QMDB_LOCATION = 'qmdb_location';
 
@@ -678,7 +678,7 @@ async function fetchAccountProofRow(
         `
             SELECT
                 ${ACCOUNT_META_BALANCE},
-                ${ACCOUNT_META_NONCE},
+                ${ACCOUNT_META_NONCE_BASE},
                 ${ACCOUNT_META_NONCE_BITMAP},
                 ${ACCOUNT_META_QMDB_LOCATION}
             FROM ${ACCOUNT_META_TABLE}
@@ -693,7 +693,7 @@ async function fetchAccountProofRow(
     }
     return {
         balance: expectBigint(row.values[ACCOUNT_META_BALANCE], ACCOUNT_META_BALANCE),
-        nonce: expectBigint(row.values[ACCOUNT_META_NONCE], ACCOUNT_META_NONCE),
+        nonce: expectBigint(row.values[ACCOUNT_META_NONCE_BASE], ACCOUNT_META_NONCE_BASE),
         nonceBitmap: expectBigint(
             row.values[ACCOUNT_META_NONCE_BITMAP],
             ACCOUNT_META_NONCE_BITMAP,

--- a/explorer/src/styles.css
+++ b/explorer/src/styles.css
@@ -562,10 +562,6 @@ body {
     padding: 0;
 }
 
-.wallet__cell .copyable--plain.is-copied {
-    color: var(--theme-accent);
-}
-
 .copyable__value {
     display: block;
     min-width: 0;
@@ -578,10 +574,6 @@ body {
     display: inline;
     overflow-wrap: anywhere;
     white-space: normal;
-}
-
-.copyable.is-copied {
-    color: var(--theme-accent);
 }
 
 .terminal-toast {

--- a/explorer/tests/nonce.test.ts
+++ b/explorer/tests/nonce.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    consumeNonce,
+    mergeNonceStates,
+    nextAvailableNonce,
+    type NonceState,
+} from '../src/nonce.ts';
+
+test('local reservation skips fetched bitmap nonces after consuming the base', () => {
+    const fetched = nonceState(0n, 0b1n);
+
+    const reserved = consumeNonce(fetched, nextAvailableNonce(fetched));
+
+    assert.deepEqual(reserved, nonceState(2n, 0n));
+});
+
+test('merging fetched nonce state keeps consumed bitmap bits', () => {
+    const local = nonceState(0n, 0n);
+    const fetched = nonceState(0n, 0b1n);
+
+    const merged = mergeNonceStates(local, fetched);
+    const reserved = consumeNonce(merged, nextAvailableNonce(merged));
+
+    assert.deepEqual(reserved, nonceState(2n, 0n));
+});
+
+function nonceState(base: bigint, bitmap: bigint): NonceState {
+    return { base, bitmap };
+}

--- a/explorer/tests/proofRetry.test.ts
+++ b/explorer/tests/proofRetry.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { isRetryableAccountProofError, isRetryableProofError } from '../src/proofRetry.ts';
+import {
+    isMissingAccountProofError,
+    isRetryableAccountProofError,
+    isRetryableProofError,
+} from '../src/proofRetry.ts';
 import { assertTransactionLocationBeforeTip, transactionProofTip } from '../src/proofMath.ts';
 
 test('SQL tx metadata misses are retried while the indexer catches up', () => {
@@ -48,6 +52,12 @@ test('account proof index catch-up errors are retried', () => {
         isRetryableAccountProofError('[out_of_range] requested proof tip is not published yet'),
         true,
     );
+});
+
+test('missing account proof rows are not retried as index catch-up', () => {
+    const detail = 'account a0bf226776...6068e27a is not indexed';
+    assert.equal(isMissingAccountProofError(detail), true);
+    assert.equal(isRetryableAccountProofError(detail), false);
 });
 
 test('QMDB account root mismatches are terminal', () => {

--- a/explorer/tsconfig.test.json
+++ b/explorer/tsconfig.test.json
@@ -20,6 +20,7 @@
         "src/blockSequence.ts",
         "src/codec.ts",
         "src/historyKey.ts",
+        "src/nonce.ts",
         "src/proofMath.ts",
         "src/proofRetry.ts"
     ]


### PR DESCRIPTION
## Overview

Adds support for 64 run-ahead nonces, enabling users to submit transactions OOO.

Follow-up work here for the morning will be some simplifications to the spammer. It no longer has to wait for a full batch to finalize before submitting the next one; it can also allow a run-ahead depth of batches up to 64.

closes #2 