### PR TITLE
ci: run Tests jobs on ubuntu-latest-8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     timeout-minutes: 60
     steps:
       - name: Checkout sources
@@ -31,7 +31,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     timeout-minutes: 60
     continue-on-error: true
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     timeout-minutes: 60
     steps:
       - name: Checkout sources
@@ -67,7 +67,7 @@ jobs:
 
   docs:
     name: Check Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     timeout-minutes: 40
     steps:
       - name: Checkout sources
@@ -86,7 +86,7 @@ jobs:
         run: just docs-test
 
   dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
     timeout-minutes: 60
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Switches all five active jobs in `.github/workflows/tests.yml` (`test`, `build`, `lint`, `docs`, `dependencies`) from `ubuntu-latest` (2 vCPU) to `ubuntu-latest-8` (8 vCPU).

## Why
These jobs are CPU-bound on Rust compilation. On the most recent run the critical path was `cargo test` at ~20m wall-clock, with lint (~15m), docs (~18m), build (~10m), and udeps (~9m) all dominated by `rustc`. The 8-core runner parallelizes `cargo`/`clippy` well and should cut wall-clock substantially.

## Notes
- The commented-out `wasm` job is left untouched.
- `ubuntu-latest-8` is already used in `commonwarexyz/monorepo` (benchmark/performance jobs), so the runner label exists at the org level. Please confirm the runner group is scoped to include this repo — if not, jobs will fail to acquire a runner.
- `ubuntu-latest-8` bills at $0.022/min vs $0.006/min for the 2-core runner (and larger runners don't draw from included minutes), so faster wall-clock comes at a higher per-minute rate.