### PR TITLE
indexer: remove clone in qmdb publisher

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "An additional cache key that is added alongside the automatic `job`-based cache key."
     required: false
     default: ""
+  rust-cache-save:
+    description: "Whether this job should save rust-cache entries when running on main."
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -65,7 +69,7 @@ runs:
     - name: Setup rust cache
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
-        save-if: ${{ github.ref == 'refs/heads/main' }}
+        save-if: ${{ github.ref == 'refs/heads/main' && inputs.rust-cache-save == 'true' }}
         key: ${{ steps.cache-key.outputs.key }}
         cache-on-failure: false
         cache-workspace-crates: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,9 +9,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  All:
+  Coverage:
+    name: "Coverage (partition: ${{ matrix.partition }}/4)"
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -19,13 +23,34 @@ jobs:
       uses: ./.github/actions/disk
     - name: Run setup
       uses: ./.github/actions/setup
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Install cargo-llvm-cov & nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov,cargo-nextest
     - name: Generate coverage report
-      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov-${{ matrix.partition }}.info --partition hash:${{ matrix.partition }}/4
+    - name: Store coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-lcov-${{ matrix.partition }}
+        path: lcov-${{ matrix.partition }}.info
+        retention-days: 1
+
+  Upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    needs: Coverage
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Download coverage reports
+      uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-lcov-*
+        merge-multiple: true
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        files: lcov.info
+        files: lcov-*.info
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main" ]
   pull_request:
 
+concurrency:
+  group: coverage-${{ github.head_ref || github.ref_name || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -23,6 +27,8 @@ jobs:
       uses: ./.github/actions/disk
     - name: Run setup
       uses: ./.github/actions/setup
+      with:
+        rust-cache-save: ${{ matrix.partition == 1 }}
     - name: Install cargo-llvm-cov & nextest
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: coverage-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,12 @@ env:
 
 jobs:
   test:
-    name: Test
+    name: "Test (partition: ${{ matrix.partition }}/4)"
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -27,7 +30,21 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - name: cargo test
-        run: cargo nextest run --workspace --all --all-features --locked
+        run: cargo nextest run --workspace --all --all-features --locked --partition hash:${{ matrix.partition }}/4
+
+  test-gate:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All tests passed successfully!"
 
   build:
     name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: tests-${{ github.head_ref || github.ref_name || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   UDEPS_VERSION: 0.1.60
@@ -27,6 +31,8 @@ jobs:
         uses: ./.github/actions/disk
       - name: Run setup
         uses: ./.github/actions/setup
+        with:
+          rust-cache-save: ${{ matrix.partition == 1 }}
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - name: cargo test

--- a/bin/validator/src/relayer.rs
+++ b/bin/validator/src/relayer.rs
@@ -578,8 +578,9 @@ fn encode_pending(batch: &DecodedBatch, pending: &HashSet<String>) -> Bytes {
     batch
         .transactions
         .iter()
-        .filter(|transaction| pending.contains(&transaction.message_digest().to_string()))
-        .cloned()
+        .zip(&batch.digests)
+        .filter(|(_, digest)| pending.contains(*digest))
+        .map(|(transaction, _)| transaction)
         .collect::<Vec<_>>()
         .encode()
 }

--- a/crates/indexer/src/publisher/block.rs
+++ b/crates/indexer/src/publisher/block.rs
@@ -7,6 +7,7 @@ use crate::publisher::{
         encode_tx_activity_row, encode_tx_meta_row,
     },
 };
+use bytes::Bytes;
 use commonware_codec::FixedSize;
 use commonware_cryptography::{Digest, Hasher, PublicKey};
 use constantinople_engine::types::EngineBlock;
@@ -27,7 +28,7 @@ pub(crate) struct IndexedBlockRows<D: Digest> {
 struct IndexedTransaction<D: Digest> {
     block_index: usize,
     digest: D,
-    bytes: Vec<u8>,
+    bytes: Bytes,
     sender: AccountKey,
     to: [u8; AccountKey::SIZE],
     value: u64,
@@ -202,7 +203,7 @@ where
     Some(IndexedTransaction {
         block_index,
         digest: hasher.finalize(),
-        bytes: signed_bytes.to_vec(),
+        bytes: signed_bytes,
         sender,
         to,
         value,

--- a/crates/indexer/src/publisher/certificate.rs
+++ b/crates/indexer/src/publisher/certificate.rs
@@ -19,7 +19,7 @@ use commonware_cryptography::{Digestible, Hasher, PublicKey, certificate::Scheme
 use constantinople_engine::types::{EngineBlock, EngineHeader};
 use exoware_sdk::{StoreClient, StoreWriteBatch};
 use exoware_simplex::{Finalized, Notarized, PreparedUpload, SimplexClient};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle, time::sleep};
 use tracing::{debug, warn};
 
@@ -56,12 +56,12 @@ where
 
     /// Queue a finalized block for digest-addressed block upload and later
     /// certificate pairing.
-    pub async fn publish_block(&self, block: &EngineBlock<H, P>)
+    pub async fn publish_block(&self, block: Arc<EngineBlock<H, P>>)
     where
         H: Hasher,
         P: PublicKey,
     {
-        let _ = self.tx.send(SimplexInput::Block(block.clone())).await;
+        let _ = self.tx.send(SimplexInput::Block(block)).await;
     }
 }
 
@@ -124,7 +124,7 @@ where
     P: PublicKey,
     S: Scheme,
 {
-    Block(EngineBlock<H, P>),
+    Block(Arc<EngineBlock<H, P>>),
     Notarization(simplex::types::Notarization<S, Commitment>),
     Finalization(simplex::types::Finalization<S, Commitment>),
 }
@@ -135,7 +135,7 @@ where
     P: PublicKey,
     S: Scheme,
 {
-    block: Option<EngineBlock<H, P>>,
+    block: Option<Arc<EngineBlock<H, P>>>,
     notarization: Option<simplex::types::Notarization<S, Commitment>>,
     finalization: Option<simplex::types::Finalization<S, Commitment>>,
 }
@@ -240,13 +240,13 @@ where
     S: Scheme + Send + Sync + 'static,
     S::Certificate: Send + Sync,
 {
-    let Some(block) = entry.block.clone() else {
+    let Some(block) = entry.block.as_deref() else {
         return false;
     };
     let mut prepared = PreparedUpload::new();
 
     if let Some(notarization) = entry.notarization.take() {
-        let certified = CertifiedHeader::new(notarization.proposal.payload, block.clone());
+        let certified = CertifiedHeader::new(notarization.proposal.payload, block);
         let notarized =
             Notarized::new(notarization, certified).expect("notarization matches certified header");
         prepared.extend(
@@ -331,7 +331,7 @@ where
     H: Hasher,
     P: PublicKey,
 {
-    fn new(commitment: Commitment, block: EngineBlock<H, P>) -> Self {
+    fn new(commitment: Commitment, block: &EngineBlock<H, P>) -> Self {
         debug_assert_eq!(commitment.block::<H::Digest>(), *block.seal());
         let header = EngineHeader::<H, P>::new_unchecked(block.header.clone(), *block.seal());
         Self { commitment, header }

--- a/crates/indexer/src/publisher/qmdb.rs
+++ b/crates/indexer/src/publisher/qmdb.rs
@@ -119,11 +119,11 @@ where
     H: Hasher,
     P: PublicKey,
 {
-    block: EngineBlock<H, P>,
+    block: Arc<EngineBlock<H, P>>,
     finalized_ts_micros: i64,
     state_start: u64,
     transaction_start: u64,
-    state_delta: Vec<StateOperation>,
+    state_delta: Arc<Vec<StateOperation>>,
 }
 
 impl<H, P> QueuedFinalizedUpload<H, P>
@@ -152,8 +152,8 @@ where
             .expect("queued finalized upload stores a validated transaction cursor")
     }
 
-    pub const fn block(&self) -> &EngineBlock<H, P> {
-        &self.block
+    pub fn block(&self) -> &EngineBlock<H, P> {
+        self.block.as_ref()
     }
 }
 
@@ -200,11 +200,11 @@ where
 
     fn read_cfg(buf: &mut impl bytes::Buf, cfg: &Self::Cfg) -> Result<Self, CodecError> {
         Ok(Self {
-            block: EngineBlock::<H, P>::read_cfg(buf, &cfg.block)?,
+            block: Arc::new(EngineBlock::<H, P>::read_cfg(buf, &cfg.block)?),
             finalized_ts_micros: i64::read(buf)?,
             state_start: u64::read(buf)?,
             transaction_start: u64::read(buf)?,
-            state_delta: Vec::<StateOperation>::read_cfg(buf, &(cfg.state_ops, ()))?,
+            state_delta: Arc::new(Vec::<StateOperation>::read_cfg(buf, &(cfg.state_ops, ()))?),
         })
     }
 }
@@ -257,7 +257,7 @@ where
 {
     height: u64,
     block_rows: IndexedBlockRows<H::Digest>,
-    state_delta: Vec<StateOperation>,
+    state_delta: Arc<Vec<StateOperation>>,
     account_rows: Vec<super::SqlRow>,
     transaction_ops: Vec<TransactionOperation<H>>,
     completion: oneshot::Sender<()>,
@@ -465,11 +465,11 @@ where
             .expect("QMDB state queue task exited")?;
 
         Ok(QueuedFinalizedUpload {
-            block,
+            block: Arc::new(block),
             finalized_ts_micros: current_time_micros(),
             state_start: state_writer_next,
             transaction_start: transaction_writer_next,
-            state_delta,
+            state_delta: Arc::new(state_delta),
         })
     }
 
@@ -2496,11 +2496,11 @@ mod tests {
         ];
 
         QueuedFinalizedUpload {
-            block,
+            block: Arc::new(block),
             finalized_ts_micros: 1_000,
             state_start: 0,
             transaction_start: 0,
-            state_delta,
+            state_delta: Arc::new(state_delta),
         }
     }
 }

--- a/crates/indexer/src/publisher/qmdb.rs
+++ b/crates/indexer/src/publisher/qmdb.rs
@@ -152,8 +152,8 @@ where
             .expect("queued finalized upload stores a validated transaction cursor")
     }
 
-    pub fn block(&self) -> &EngineBlock<H, P> {
-        self.block.as_ref()
+    pub fn block(&self) -> Arc<EngineBlock<H, P>> {
+        Arc::clone(&self.block)
     }
 }
 
@@ -452,8 +452,8 @@ where
         let state_end = block.header.state_range.end();
         validate_writer_range(state_writer_next, state_end, block.header.height)?;
         transaction_upload_end(transaction_writer_next, block)?;
-        let block = block.clone();
-        let state_block = block.clone();
+        let block = Arc::new(block.clone());
+        let state_block = Arc::clone(&block);
         let state_db = databases.0.clone();
         let state_delta = context
             .child("state_delta")
@@ -465,7 +465,7 @@ where
             .expect("QMDB state queue task exited")?;
 
         Ok(QueuedFinalizedUpload {
-            block: Arc::new(block),
+            block,
             finalized_ts_micros: current_time_micros(),
             state_start: state_writer_next,
             transaction_start: transaction_writer_next,

--- a/crates/indexer/src/publisher/sql.rs
+++ b/crates/indexer/src/publisher/sql.rs
@@ -1,6 +1,7 @@
 //! SQL row encoding shared by the combined publisher.
 
 use crate::sql_schema::{ACCOUNT_META_TABLE, BLOCK_META_TABLE, TX_ACTIVITY_TABLE, TX_META_TABLE};
+use bytes::Bytes;
 use exoware_sql::CellValue;
 
 /// One row destined for a SQL metadata table.
@@ -28,7 +29,7 @@ pub(crate) struct BlockMetaRow {
 pub(crate) struct TxMetaRow {
     pub digest: [u8; 32],
     pub qmdb_location: u64,
-    pub body: Vec<u8>,
+    pub body: Bytes,
 }
 
 /// Transaction activity role stored in `tx_activity`.

--- a/crates/primitives/src/signed.rs
+++ b/crates/primitives/src/signed.rs
@@ -232,6 +232,19 @@ where
             .as_ref()
     }
 
+    /// Consumes the lazy transaction, returning the decoded value if decoding
+    /// succeeds.
+    ///
+    /// Moves the cached value out when this handle is its only owner; clones
+    /// only when the decoded value is still shared with another handle.
+    pub fn into_value(self) -> Option<SignedTransaction<H>> {
+        self.get()?;
+        match Arc::try_unwrap(self.value) {
+            Ok(value) => value.into_inner().flatten(),
+            Err(shared) => shared.get().expect("value was forced above").clone(),
+        }
+    }
+
     /// Returns the encoded signed transaction bytes without the lazy length prefix.
     ///
     /// If this value came from block decoding, this clones the deferred bytes and
@@ -341,7 +354,7 @@ where
     St: Strategy,
 {
     strategy
-        .map_collect_vec(transactions, |lazy| lazy.get().cloned())
+        .map_collect_vec(transactions, LazySignedTransaction::into_value)
         .into_iter()
         .collect()
 }
@@ -503,7 +516,7 @@ where
     // Each lazy was forced during verification above, so materialization cannot fail here.
     transactions
         .into_iter()
-        .map(|lazy| lazy.get().cloned())
+        .map(LazySignedTransaction::into_value)
         .collect()
 }
 

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -89,6 +89,26 @@ where
     }
 }
 
+// Encoding borrowed transactions lets collections like `Vec<&SignedTransaction>`
+// encode without cloning each transaction first.
+impl<H> Write for &SignedTransaction<H>
+where
+    H: Hasher,
+{
+    fn write(&self, buf: &mut impl BufMut) {
+        (**self).write(buf);
+    }
+}
+
+impl<H> EncodeSize for &SignedTransaction<H>
+where
+    H: Hasher,
+{
+    fn encode_size(&self) -> usize {
+        (**self).encode_size()
+    }
+}
+
 impl<H> Read for SignedTransaction<H>
 where
     H: Hasher,


### PR DESCRIPTION
The deep clone itself was expensive, and amplified memory usage when channels are filled under back pressure. Fix is to use `Arc`.