### PR TITLE
deploy: add deploy parameter options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,13 +1481,17 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tracing",
@@ -2931,8 +2935,7 @@ dependencies = [
 [[package]]
 name = "exoware-qmdb"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac764c476e980b5f535f930316e8888728f7554fae7578e318e097c87f6d5f88"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "axum",
  "buffa",
@@ -2962,8 +2965,7 @@ dependencies = [
 [[package]]
 name = "exoware-sdk"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494af0d8515926c8ace9fe1fdb63981963d6a05b776ca45fa3027cb27e8a265d"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "anyhow",
  "base64",
@@ -2981,6 +2983,7 @@ dependencies = [
  "psl",
  "regex",
  "reqwest",
+ "rustls-platform-verifier",
  "serde",
  "thiserror",
  "tokio",
@@ -2991,8 +2994,7 @@ dependencies = [
 [[package]]
 name = "exoware-server"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303ce3e340fcf8c6ea26dfbd5714884675299a0655ff2627f8cb3e7cfc1bc1ff"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "buffa",
  "buffa-types",
@@ -3009,8 +3011,7 @@ dependencies = [
 [[package]]
 name = "exoware-simplex"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b84e30aef4a827cc4ecc07fcf582a0987214e492098af947ef04e78120b622"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "bytes",
  "clap",
@@ -3035,13 +3036,13 @@ dependencies = [
 [[package]]
 name = "exoware-simulator"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cebf2c3e8f9bff077341b9cc3556e7b91215938febdfe5eb7ee317306f999a"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "axum",
  "buffa",
  "bytes",
  "clap",
+ "commonware-codec",
  "exoware-sdk",
  "exoware-server",
  "mimalloc",
@@ -3059,8 +3060,7 @@ dependencies = [
 [[package]]
 name = "exoware-sql"
 version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9c3cfa2c70cf722b5b261ccaf0bad52a8df6779c745669cdaf54dcbfd1907c"
+source = "git+https://github.com/exowarexyz/monorepo.git?rev=8150d0f2a9037875c06f5d833a9617169739bfe3#8150d0f2a9037875c06f5d833a9617169739bfe3"
 dependencies = [
  "async-trait",
  "axum",
@@ -5122,6 +5122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,15 @@ derive_more = { version = "2.1.1", default-features = false }
 prometheus-client = { version = "0.24.0", default-features = false }
 tracing-subscriber = "0.3"
 
+[patch.crates-io]
+# All Exoware libraries must share one SDK crate instance because SDK types cross crate boundaries.
+exoware-qmdb = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+exoware-sdk = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+exoware-server = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+exoware-simplex = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+exoware-simulator = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+exoware-sql = { git = "https://github.com/exowarexyz/monorepo.git", rev = "8150d0f2a9037875c06f5d833a9617169739bfe3" }
+
 [profile.samply]
 inherits = "release"
 debug = true

--- a/bin/deploy/README.md
+++ b/bin/deploy/README.md
@@ -411,6 +411,16 @@ Topology and defaults:
 - `qmdb-indexer` listens on port `8092` by default.
 - Full indexer uploads are enabled on only the indexer secondary.
 
+### External store (no chain-indexer)
+
+Pass `--chain-indexer-url <url>` to point every store consumer (the indexer
+secondary, `metadata-indexer`, and `qmdb-indexer`) at an external exoware store
+that supports reads and writes instead of provisioning the simulator-backed
+`chain-indexer` host. The URL is used verbatim, so it must be reachable from
+the instances' network. HTTP and HTTPS URLs are supported. No `chain-indexer`
+instance, binary, config, or port rule is generated. The other
+`--chain-indexer-*` flags are ignored.
+
 QMDB rows are committed by validators through the shared `chain-indexer` Store URL, not by sending
 writes to `qmdb-indexer`. The QMDB facade only serves reads: account-state operation-log APIs are
 mounted under `/state`, and transaction-hash operation-log APIs are mounted under `/transactions`.

--- a/bin/deploy/src/local.rs
+++ b/bin/deploy/src/local.rs
@@ -355,7 +355,9 @@ fn local_run_commands(
             relayer_http_port(args, local).expect("--spammer requires a relayer secondary");
         let network_source = format!(
             "--relayer-url http://127.0.0.1:{} --relayer-submitters {} --relayer-targets {}",
-            relayer_port, args.validators, targets,
+            relayer_port,
+            args.spammer_submitters.unwrap_or(args.validators as usize),
+            targets,
         );
 
         // Place the spammer's metrics port past the primary and secondary ranges
@@ -426,6 +428,7 @@ mod tests {
             spammer_seed_offset: 1000,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
+            spammer_submitters: None,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
             target: GenerateTarget::Local(test_local_args()),
         }

--- a/bin/deploy/src/main.rs
+++ b/bin/deploy/src/main.rs
@@ -158,6 +158,12 @@ pub(crate) struct GenerateArgs {
     /// txs per batch.
     #[arg(long, default_value_t = 0.0, value_parser = parse_accounts_jitter)]
     spammer_accounts_jitter: f64,
+    /// Concurrent spammer submitters, each cycling its own account range with
+    /// one batch in flight (defaults to the validator count). Offered load is
+    /// roughly submitters x accounts per finalization round trip, so set this
+    /// explicitly to keep load constant when the validator count changes.
+    #[arg(long = "spammer-submitters")]
+    spammer_submitters: Option<usize>,
     /// Fully signed local batches to keep ready per spammer submitter.
     #[arg(long, default_value_t = DEFAULT_SPAMMER_PRESIGNED_BATCHES)]
     spammer_presigned_batches: usize,
@@ -224,6 +230,12 @@ pub(crate) struct RemoteArgs {
     /// consensus does.
     #[arg(long = "storage-throughput")]
     storage_throughput: Option<i32>,
+    /// Absolute HTTP or HTTPS URL of an external exoware store that supports reads and writes.
+    /// The URL is used verbatim by every store consumer. Providing it replaces
+    /// the simulator-backed chain-indexer. No chain-indexer instance, binary,
+    /// config, or port rule is generated.
+    #[arg(long = "chain-indexer-url")]
+    chain_indexer_url: Option<String>,
     /// Instance type for the shared chain-indexer instance.
     #[arg(long = "chain-indexer-instance-type", default_value = DEFAULT_CHAIN_INDEXER_INSTANCE_TYPE)]
     chain_indexer_instance_type: String,
@@ -616,6 +628,11 @@ pub(crate) fn validate_generate_args(args: &GenerateArgs) {
         !args.spammer || args.relayer,
         "--spammer requires --relayer"
     );
+    assert!(args.validators >= 4, "--validators must be at least 4");
+    assert!(
+        args.spammer_submitters != Some(0),
+        "--spammer-submitters must be at least 1"
+    );
 }
 
 pub(crate) fn generate_local_cluster_material(
@@ -942,6 +959,27 @@ mod tests {
         };
         let generate = *generate;
         assert_eq!(generate.spammer_rayon_threads, 6);
+    }
+
+    #[test]
+    #[should_panic(expected = "--validators must be at least 4")]
+    fn rejects_validator_count_below_coding_minimum() {
+        let cli = Cli::try_parse_from([
+            "constantinople-deploy",
+            "generate",
+            "--validators",
+            "3",
+            "--output-dir",
+            "out",
+            "local",
+        ])
+        .expect("local invocation should parse");
+
+        let Command::Generate(generate) = cli.command else {
+            panic!("expected generate command");
+        };
+
+        super::validate_generate_args(&generate);
     }
 
     #[test]

--- a/bin/deploy/src/remote.rs
+++ b/bin/deploy/src/remote.rs
@@ -88,20 +88,22 @@ pub(super) fn generate(args: &GenerateArgs, remote: &RemoteArgs) {
     );
     if indexer_enabled(args) {
         info!(
-            chain_indexer_port = remote.chain_indexer_port,
+            store_url = %store_url(remote),
             metadata_indexer_port = remote.metadata_indexer_port,
             qmdb_indexer_port = remote.qmdb_indexer_port,
             "configured shared remote indexer services"
         );
     }
     let mut binaries = vec![output_dir.join(VALIDATOR_BINARY_FILE).display().to_string()];
-    if indexer_enabled(args) {
+    if local_chain_indexer(args, remote) {
         binaries.push(
             output_dir
                 .join(CHAIN_INDEXER_BINARY_FILE)
                 .display()
                 .to_string(),
         );
+    }
+    if indexer_enabled(args) {
         binaries.push(
             output_dir
                 .join(METADATA_INDEXER_BINARY_FILE)
@@ -227,8 +229,7 @@ fn build_secondaries(
             public_key_cache_size: args.public_key_cache_size,
             traces: remote.traces,
             bootstrappers: bootstrappers.clone(),
-            indexer: matches!(role, SecondaryRole::Indexer)
-                .then(|| remote_indexer_config(remote.chain_indexer_port)),
+            indexer: matches!(role, SecondaryRole::Indexer).then(|| remote_indexer_config(remote)),
             relayer: matches!(role, SecondaryRole::Relayer)
                 .then(|| remote_relayer_config(remote, material)),
         };
@@ -246,9 +247,27 @@ fn build_secondaries(
     secondaries
 }
 
-fn remote_indexer_config(port: u16) -> IndexerConfig {
+// The store URL every consumer dials: the external store when one is supplied,
+// otherwise the deployer-provisioned chain-indexer host (whose name each binary
+// resolves to an IP via its hosts file). An external URL is used verbatim, so
+// it must be reachable from the instances' network.
+fn store_url(remote: &RemoteArgs) -> String {
+    remote
+        .chain_indexer_url
+        .clone()
+        .unwrap_or_else(|| format!("http://{CHAIN_INDEXER_HOST}:{}", remote.chain_indexer_port))
+}
+
+// Whether this deployment provisions its own chain-indexer host. An external
+// store replaces the instance and everything that exists only to serve it
+// (binary, config, port rule).
+const fn local_chain_indexer(args: &GenerateArgs, remote: &RemoteArgs) -> bool {
+    indexer_enabled(args) && remote.chain_indexer_url.is_none()
+}
+
+fn remote_indexer_config(remote: &RemoteArgs) -> IndexerConfig {
     IndexerConfig {
-        chain_indexer_url: format!("http://{CHAIN_INDEXER_HOST}:{port}"),
+        chain_indexer_url: store_url(remote),
         upload_buffer: INDEXER_UPLOAD_BUFFER,
     }
 }
@@ -278,7 +297,7 @@ fn remote_spammer_config(
         rayon_threads: args.spammer_rayon_threads,
         http_port: remote.http_port,
         relayer_url: relayer_url(args, remote, material),
-        relayer_submitters: args.validators as usize,
+        relayer_submitters: args.spammer_submitters.unwrap_or(args.validators as usize),
         presigned_batches: args.spammer_presigned_batches,
         primary_validators: material.primary_hex(),
         accounts_jitter: args.spammer_accounts_jitter,
@@ -292,7 +311,7 @@ fn relayer_url(args: &GenerateArgs, remote: &RemoteArgs, material: &ClusterMater
 }
 
 fn chain_indexer_config(args: &GenerateArgs, remote: &RemoteArgs) -> Option<ChainIndexerConfig> {
-    indexer_enabled(args).then(|| ChainIndexerConfig {
+    local_chain_indexer(args, remote).then(|| ChainIndexerConfig {
         port: remote.chain_indexer_port,
         data_dir: PathBuf::from(CHAIN_INDEXER_DATA_DIR),
         db_parallelism: remote.chain_indexer_db_parallelism,
@@ -305,14 +324,14 @@ fn metadata_indexer_config(
 ) -> Option<MetadataIndexerConfig> {
     indexer_enabled(args).then(|| MetadataIndexerConfig {
         port: remote.metadata_indexer_port,
-        chain_indexer_url: format!("http://{CHAIN_INDEXER_HOST}:{}", remote.chain_indexer_port),
+        chain_indexer_url: store_url(remote),
     })
 }
 
 fn qmdb_indexer_config(args: &GenerateArgs, remote: &RemoteArgs) -> Option<QmdbIndexerConfig> {
     indexer_enabled(args).then(|| QmdbIndexerConfig {
         port: remote.qmdb_indexer_port,
-        chain_indexer_url: format!("http://{CHAIN_INDEXER_HOST}:{}", remote.chain_indexer_port),
+        chain_indexer_url: store_url(remote),
     })
 }
 
@@ -371,7 +390,7 @@ fn build_deployer_config(
         });
     }
 
-    if indexer_enabled {
+    if local_chain_indexer(args, remote) {
         instances.push(aws::InstanceConfig {
             name: CHAIN_INDEXER_HOST.to_string(),
             region: shared_indexer_region.clone(),
@@ -385,6 +404,9 @@ fn build_deployer_config(
             config: CHAIN_INDEXER_CONFIG_FILE.to_string(),
             profiling: false,
         });
+    }
+
+    if indexer_enabled {
         instances.push(aws::InstanceConfig {
             name: crate::METADATA_INDEXER_HOST.to_string(),
             region: shared_indexer_region.clone(),
@@ -443,23 +465,26 @@ fn build_deployer_config(
             dashboard: dashboard.to_string(),
         },
         instances,
-        ports: port_configs(remote, indexer_enabled),
+        ports: port_configs(args, remote),
     }
 }
 
-fn port_configs(remote: &RemoteArgs, indexer_enabled: bool) -> Vec<aws::PortConfig> {
+fn port_configs(args: &GenerateArgs, remote: &RemoteArgs) -> Vec<aws::PortConfig> {
     let mut ports = vec![aws::PortConfig {
         protocol: "tcp".to_string(),
         port: remote.listen_port,
         cidr: "0.0.0.0/0".to_string(),
     }];
 
-    if indexer_enabled {
+    if local_chain_indexer(args, remote) {
         ports.push(aws::PortConfig {
             protocol: "tcp".to_string(),
             port: remote.chain_indexer_port,
             cidr: "0.0.0.0/0".to_string(),
         });
+    }
+
+    if indexer_enabled(args) {
         ports.push(aws::PortConfig {
             protocol: "tcp".to_string(),
             port: remote.metadata_indexer_port,
@@ -521,6 +546,7 @@ mod tests {
             spammer_seed_offset: 1000,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
+            spammer_submitters: None,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
             target: GenerateTarget::Local(LocalArgs {
                 base_port: 9000,
@@ -541,6 +567,7 @@ mod tests {
             storage_size: 25,
             storage_iops: None,
             storage_throughput: None,
+            chain_indexer_url: None,
             chain_indexer_instance_type: DEFAULT_CHAIN_INDEXER_INSTANCE_TYPE.to_string(),
             chain_indexer_storage_size: DEFAULT_CHAIN_INDEXER_STORAGE_SIZE,
             chain_indexer_storage_iops: DEFAULT_CHAIN_INDEXER_STORAGE_IOPS,
@@ -692,6 +719,23 @@ mod tests {
         );
     }
 
+    // Offered load is submitters x accounts per round trip, so the flag exists
+    // to hold load constant when the validator count changes; the default keeps
+    // the pre-flag coupling.
+    #[test]
+    fn remote_spammer_submitters_flag_overrides_validator_count() {
+        let mut args = generate_args();
+        args.spammer = true;
+        args.relayer = true;
+        args.spammer_submitters = Some(50);
+        let remote = remote_args();
+        let material = generate_local_cluster_material(args.validators, total_secondaries(&args));
+
+        let relayed = remote_spammer_config(&args, &remote, &material);
+
+        assert_eq!(relayed.relayer_submitters, 50);
+    }
+
     #[test]
     fn remote_deployer_config_includes_secondaries_and_indexers() {
         let mut args = generate_args();
@@ -700,8 +744,7 @@ mod tests {
         let remote = remote_args();
         let validators = vec![validator(0), validator(1), validator(2)];
         let mut indexer_secondary_config = validator(0).config;
-        indexer_secondary_config.indexer =
-            Some(super::remote_indexer_config(remote.chain_indexer_port));
+        indexer_secondary_config.indexer = Some(super::remote_indexer_config(&remote));
         let secondaries = vec![
             super::GeneratedValidator {
                 public_key_hex: "secondary-0".to_string(),
@@ -735,13 +778,69 @@ mod tests {
 
     #[test]
     fn remote_ports_only_open_http_for_explicit_cidrs() {
+        let args = generate_args();
         let mut remote = remote_args();
         remote.http_cidrs.clear();
 
-        let ports = port_configs(&remote, false);
+        let ports = port_configs(&args, &remote);
 
         assert_eq!(ports.len(), 1);
         assert_eq!(ports[0].port, 9000);
+    }
+
+    // An external store must replace the chain-indexer wholesale: every consumer
+    // dials the URL verbatim, and nothing that exists only to serve the local
+    // simulator (instance, config, port rule) is generated.
+    #[test]
+    fn remote_external_store_url_replaces_chain_indexer() {
+        let mut args = generate_args();
+        args.indexer = true;
+        args.relayer = true;
+        let mut remote = remote_args();
+        remote.chain_indexer_url = Some("https://store.example.xyz".to_string());
+        let material = generate_local_cluster_material(args.validators, total_secondaries(&args));
+
+        let secondaries = build_secondaries(&args, &remote, Path::new("/tmp/configs"), &material);
+        let indexer = secondaries[0]
+            .config
+            .indexer
+            .as_ref()
+            .expect("secondary should have indexer wiring");
+        assert_eq!(indexer.chain_indexer_url, "https://store.example.xyz");
+
+        assert!(
+            super::chain_indexer_config(&args, &remote).is_none(),
+            "no chain-indexer config should be generated for an external store"
+        );
+        let metadata = super::metadata_indexer_config(&args, &remote)
+            .expect("metadata indexer should still be generated");
+        assert_eq!(metadata.chain_indexer_url, "https://store.example.xyz");
+        let qmdb = super::qmdb_indexer_config(&args, &remote)
+            .expect("qmdb indexer should still be generated");
+        assert_eq!(qmdb.chain_indexer_url, "https://store.example.xyz");
+
+        let validators = vec![validator(0), validator(1), validator(2)];
+        let config = build_deployer_config(
+            &args,
+            &remote,
+            VALIDATOR_BINARY_FILE,
+            "dashboard.json",
+            &validators,
+            &secondaries,
+        );
+
+        // 3 primaries + 2 secondaries + metadata/qmdb indexers; no chain-indexer.
+        assert_eq!(config.instances.len(), 7);
+        assert!(
+            config.instances.iter().all(|i| i.name != "chain-indexer"),
+            "no chain-indexer instance should be provisioned for an external store"
+        );
+
+        let ports = port_configs(&args, &remote);
+        assert!(
+            ports.iter().all(|p| p.port != remote.chain_indexer_port),
+            "the chain-indexer port should not be opened for an external store"
+        );
     }
 
     #[test]
@@ -779,8 +878,7 @@ mod tests {
         let remote = remote_args();
         let validators = vec![validator(0), validator(1), validator(2)];
         let mut indexer_secondary_config = validator(0).config;
-        indexer_secondary_config.indexer =
-            Some(super::remote_indexer_config(remote.chain_indexer_port));
+        indexer_secondary_config.indexer = Some(super::remote_indexer_config(&remote));
         let secondaries = vec![
             super::GeneratedValidator {
                 public_key_hex: "secondary-0".to_string(),

--- a/bin/validator/src/run.rs
+++ b/bin/validator/src/run.rs
@@ -920,6 +920,7 @@ fn run_with_config(config: LoadedConfig, config_path: PathBuf) {
                 genesis_leader: decoded.genesis_leader,
                 transaction_namespace: constantinople_primitives::TRANSACTION_NAMESPACE,
                 block_codec: Default::default(),
+                max_block_transaction_bytes: max_propose_bytes,
                 prunable_items_per_section: PRUNABLE_ITEMS_PER_SECTION,
                 state_page_cache_bytes,
                 other_page_cache_bytes,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -12,7 +12,8 @@
 //! optional local share.
 
 use crate::types::*;
-use commonware_coding::CodecConfig;
+use commonware_codec::FixedSize;
+use commonware_coding::{CodecConfig, Config as CodingConfig};
 use commonware_consensus::{
     Reporter, Reporters,
     marshal::{
@@ -60,7 +61,7 @@ use constantinople_application::consensus::{
     Application, FinalizedHookFn, StateSyncTarget, TransactionHistoryTarget,
 };
 use constantinople_mempool::TransactionSource;
-use constantinople_primitives::{BlockCfg, PublicKeyCache};
+use constantinople_primitives::{Block, BlockCfg, PublicKeyCache};
 use futures::future::try_join_all;
 use rand::CryptoRng;
 use std::{
@@ -85,6 +86,7 @@ pub const MAX_PENDING_ACKS: NonZero<usize> = NZUsize!(4);
 const WITNESS_ITEMS_PER_SECTION: NonZero<u64> = NZU64!(64);
 const SHARD_BACKGROUND_CHANNEL_CAPACITY: NonZero<usize> = NZUsize!(1024);
 const SHARD_PEER_BUFFER_SIZE: NonZero<usize> = NZUsize!(64);
+const MINIMUM_HONEST_SHARDS: usize = 2;
 const DB_WRITE_BUFFER: NonZero<usize> = NZUsize!(8 * 1024 * 1024);
 const STATE_INIT_CACHE_SIZE: NonZero<usize> = NZUsize!(1 << 18);
 const STATE_SYNC_INITIAL: Duration = Duration::from_secs(1);
@@ -175,6 +177,8 @@ where
     pub genesis_leader: C::PublicKey,
     pub transaction_namespace: &'static [u8],
     pub block_codec: BlockCfg,
+    /// Maximum total encoded transaction bytes in a proposed block.
+    pub max_block_transaction_bytes: usize,
     pub prunable_items_per_section: NonZero<u64>,
     /// Capacity in bytes of the state QMDB page cache.
     ///
@@ -467,8 +471,13 @@ where
             shards::Config {
                 scheme_provider: provider.clone(),
                 blocker: config.blocker.clone(),
+                // The f = 1 coding threshold produces the largest honest shard.
+                // Higher fault thresholds split the same block across more
+                // original shards.
                 shard_codec_cfg: CodecConfig {
-                    maximum_shard_size: 1024 * 1024,
+                    maximum_shard_size: maximum_honest_shard_size::<H, C::PublicKey>(
+                        config.max_block_transaction_bytes,
+                    ),
                 },
                 block_codec_cfg: config.block_codec.clone(),
                 strategy: config.strategy.clone(),
@@ -654,6 +663,23 @@ where
     }
 }
 
+fn maximum_honest_shard_size<H, P>(max_transaction_bytes: usize) -> usize
+where
+    H: Hasher,
+    P: PublicKey,
+{
+    let max_block_size = Block::<Commitment, P, H>::maximum_encoded_size(max_transaction_bytes);
+
+    // The coding input contains the block and its coding config. Reed-Solomon
+    // adds a payload-length prefix and requires an even shard width.
+    let prefixed_size = max_block_size
+        .checked_add(CodingConfig::SIZE)
+        .and_then(|size| size.checked_add(u32::SIZE))
+        .expect("maximum coded block size must fit in usize");
+    let shard_size = prefixed_size.div_ceil(MINIMUM_HONEST_SHARDS);
+    shard_size + shard_size % 2
+}
+
 fn threshold_scheme<C, V>(
     namespace: &[u8],
     output: &Output<V, C::PublicKey>,
@@ -813,5 +839,93 @@ where
             write_buffer: DB_WRITE_BUFFER,
         },
         commit_codec_config: (),
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use commonware_codec::{Decode, Encode, EncodeSize};
+    use commonware_coding::ReedSolomon;
+    use commonware_consensus::{
+        marshal::coding::types::Shard,
+        simplex::types::Context,
+        types::{Epoch, Round, View},
+    };
+    use commonware_cryptography::{Digest, Signer, ed25519, sha256};
+    use commonware_math::algebra::Random;
+    use commonware_parallel::Sequential;
+    use commonware_utils::{NZU16, non_empty_range};
+    use constantinople_primitives::{Sealable, Transaction, TransactionPublicKey};
+    use core::num::NonZeroU64;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn honest_shard_bound_uses_two_original_shards() {
+        assert_eq!(
+            maximum_honest_shard_size::<sha256::Sha256, ed25519::PublicKey>(16 * 1024 * 1024),
+            8_502_898
+        );
+    }
+
+    #[test]
+    fn honest_shard_bound_accepts_maximum_shard() {
+        type TestShard = Shard<ReedSolomon<sha256::Sha256>, sha256::Sha256>;
+
+        let mut rng = StdRng::from_seed([13u8; 32]);
+        let signer = ed25519::PrivateKey::random(&mut rng);
+        let public_key = TransactionPublicKey::ed25519(signer.public_key());
+        let transaction = Transaction::<sha256::Digest>::new(
+            public_key.clone(),
+            public_key,
+            NonZeroU64::new(1).expect("test value should be non-zero"),
+            0,
+        )
+        .seal_and_sign(
+            &signer,
+            constantinople_primitives::TRANSACTION_NAMESPACE,
+            &mut sha256::Sha256::default(),
+        );
+        let max_transaction_bytes = transaction.encode_size();
+        let header = constantinople_primitives::Header {
+            context: Context {
+                round: Round::new(Epoch::new(u64::MAX), View::new(u64::MAX)),
+                leader: signer.public_key(),
+                parent: (View::new(u64::MAX), Commitment::default()),
+            },
+            parent: sha256::Digest::EMPTY,
+            height: u64::MAX,
+            timestamp: u64::MAX,
+            state_root: sha256::Digest::EMPTY,
+            state_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+            transactions_root: sha256::Digest::EMPTY,
+            transactions_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+        };
+        let block = Block::new(header, vec![transaction]).seal(&mut sha256::Sha256::default());
+        let coding_config = CodingConfig {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(2),
+        };
+        let coded = EngineCodedBlock::new(block, coding_config, &Sequential);
+        let encoded = coded
+            .shard(0)
+            .expect("coded block should contain shard zero")
+            .encode();
+        let maximum_shard_size =
+            maximum_honest_shard_size::<sha256::Sha256, ed25519::PublicKey>(max_transaction_bytes);
+
+        assert_eq!(maximum_shard_size, 232);
+        assert!(
+            TestShard::decode_cfg(encoded.clone(), &CodecConfig { maximum_shard_size },).is_ok()
+        );
+        assert!(
+            TestShard::decode_cfg(
+                encoded,
+                &CodecConfig {
+                    maximum_shard_size: maximum_shard_size - 1,
+                },
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/engine/src/tests/mod.rs
+++ b/crates/engine/src/tests/mod.rs
@@ -342,6 +342,7 @@ impl EngineDefinition for TestEngineDefinition {
                     genesis_leader,
                     transaction_namespace: TRANSACTION_NAMESPACE,
                     block_codec: Default::default(),
+                    max_block_transaction_bytes: 16 * 1024 * 1024,
                     prunable_items_per_section,
                     probe: probe_mailbox.clone(),
                     simplex_observer: None,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -5,8 +5,13 @@
 //! - [`Header`] - The execution header.
 //! - [`Block`] - Execution payload and required consensus metadata.
 
-use crate::{LazySignedTransaction, Sealable, Sealed, SignedTransaction};
-use commonware_codec::{Encode, EncodeSize, Error as CodecError, RangeCfg, Read, ReadExt, Write};
+use crate::{
+    LazySignedTransaction, Sealable, Sealed, SignedTransaction, Transaction, TransactionSignature,
+};
+use commonware_codec::{
+    Encode, EncodeSize, Error as CodecError, FixedSize, RangeCfg, Read, ReadExt, Write,
+    varint::MAX_U64_VARINT_SIZE,
+};
 use commonware_consensus::{
     Block as ConsensusBlock, CertifiableBlock, Heightable, simplex::types::Context, types::Height,
 };
@@ -45,6 +50,12 @@ where
     D: Digest,
     P: PublicKey,
 {
+    const MAX_ENCODED_SIZE: usize = 3 * MAX_U64_VARINT_SIZE
+        + <C as FixedSize>::SIZE
+        + <P as FixedSize>::SIZE
+        + 3 * <D as FixedSize>::SIZE
+        + 6 * u64::SIZE;
+
     /// Hashes the encoded header to produce a digest.
     pub fn hash_slow<H: Hasher<Digest = D>>(&self, hasher: &mut H) -> D {
         hasher.update(self.encode().as_ref());
@@ -229,6 +240,32 @@ where
     P: PublicKey,
     H: Hasher,
 {
+    /// Returns an upper bound on encoded block size for a transaction-byte budget.
+    pub fn maximum_encoded_size(max_transaction_bytes: usize) -> usize {
+        let minimum_transaction_size =
+            Transaction::<H::Digest>::SIZE + TransactionSignature::MIN_SIZE;
+        let maximum_transactions = max_transaction_bytes / minimum_transaction_size;
+        let maximum_transaction_size =
+            Transaction::<H::Digest>::SIZE + TransactionSignature::MAX_SIZE;
+        let maximum_transaction_prefix_bytes = maximum_transaction_size.encode_size();
+
+        // Lazy transactions prefix each signed transaction with its encoded length.
+        let maximum_lazy_prefix_bytes = maximum_transactions
+            .checked_mul(maximum_transaction_prefix_bytes)
+            .expect("maximum transaction prefix size must fit in usize");
+        let maximum_body_bytes = if maximum_transactions == 0 {
+            0
+        } else {
+            max_transaction_bytes
+        };
+
+        Header::<C, H::Digest, P>::MAX_ENCODED_SIZE
+            .checked_add(maximum_transactions.encode_size())
+            .and_then(|size| size.checked_add(maximum_lazy_prefix_bytes))
+            .and_then(|size| size.checked_add(maximum_body_bytes))
+            .expect("maximum encoded block size must fit in usize")
+    }
+
     /// Creates a new block from already-decoded transactions.
     pub fn new(header: Header<C, H::Digest, P>, body: Vec<SignedTransaction<H>>) -> Self {
         Self {
@@ -452,6 +489,54 @@ mod tests {
         let mut buf = Vec::new();
         block.write(&mut buf);
         assert_eq!(buf.len(), expected);
+    }
+
+    #[test]
+    fn maximum_encoded_size_includes_block_framing() {
+        use commonware_consensus::types::coding::Commitment;
+
+        type ProductionBlock = Block<Commitment, ed25519::PublicKey, sha256::Sha256>;
+
+        let mut rng = StdRng::from_seed([11u8; 32]);
+        let signer = ed25519::PrivateKey::random(&mut rng);
+        let public_key = crate::TransactionPublicKey::ed25519(signer.public_key());
+        let transaction = crate::Transaction::<sha256::Digest>::new(
+            public_key.clone(),
+            public_key,
+            core::num::NonZeroU64::new(1).expect("test value should be non-zero"),
+            0,
+        )
+        .seal_and_sign(
+            &signer,
+            crate::TRANSACTION_NAMESPACE,
+            &mut sha256::Sha256::default(),
+        );
+        let max_transaction_bytes = transaction.encode_size();
+        let header = Header {
+            context: Context {
+                round: Round::new(Epoch::new(u64::MAX), View::new(u64::MAX)),
+                leader: signer.public_key(),
+                parent: (View::new(u64::MAX), Commitment::default()),
+            },
+            parent: sha256::Digest::EMPTY,
+            height: u64::MAX,
+            timestamp: u64::MAX,
+            state_root: sha256::Digest::EMPTY,
+            state_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+            transactions_root: sha256::Digest::EMPTY,
+            transactions_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+        };
+        let block = ProductionBlock::new(header, vec![transaction]);
+
+        assert_eq!(
+            block.encode_size(),
+            ProductionBlock::maximum_encoded_size(max_transaction_bytes)
+        );
+
+        assert_eq!(
+            ProductionBlock::maximum_encoded_size(16 * 1024 * 1024),
+            17_005_785
+        );
     }
 
     #[test]

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,36 +3,142 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+usage() {
+    echo "usage $0 [options]" >&2
+    echo "  --store-url <url>                       default managed chain-indexer" >&2
+    echo "  --validators <count>                    default 50" >&2
+    echo "  --regions <comma-separated-regions>     default us-east-1,us-west-2" >&2
+    echo "  --spammer-accounts <count>              default 4096" >&2
+    echo "  --spammer-submitters <count>            default validator count" >&2
+    echo "  --max-pool-bytes <bytes>                default deploy CLI value" >&2
+    echo "  --storage-size <gib>                    default 150" >&2
+}
+
+if [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+STORE_URL=
+EXTERNAL_STORE=false
+VALIDATORS=50
+REGIONS=us-east-1,us-west-2
+SPAMMER_ACCOUNTS=4096
+SPAMMER_SUBMITTERS=
+MAX_POOL_BYTES=
+STORAGE_SIZE=150
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --store-url)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            STORE_URL=$2
+            EXTERNAL_STORE=true
+            shift 2
+            ;;
+        --validators)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            VALIDATORS=$2
+            shift 2
+            ;;
+        --regions)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            REGIONS=$2
+            shift 2
+            ;;
+        --spammer-accounts)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            SPAMMER_ACCOUNTS=$2
+            shift 2
+            ;;
+        --spammer-submitters)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            SPAMMER_SUBMITTERS=$2
+            shift 2
+            ;;
+        --max-pool-bytes)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            MAX_POOL_BYTES=$2
+            shift 2
+            ;;
+        --storage-size)
+            [ "$#" -ge 2 ] || { echo "missing value for $1" >&2; exit 2; }
+            STORAGE_SIZE=$2
+            shift 2
+            ;;
+        *)
+            echo "unknown option $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+GENERATE_ARGS=(
+    --validators "$VALIDATORS"
+    --relayer
+    --spammer
+    --indexer
+    --spammer-accounts "$SPAMMER_ACCOUNTS"
+    --spammer-accounts-jitter 0.1
+    --spammer-rayon-threads 14
+    --output-dir ./deploy
+    --worker-threads 3
+    --rayon-threads 13
+    --public-key-cache-size 5000000
+    --max-propose-bytes 16777216
+)
+
+if [ -n "$SPAMMER_SUBMITTERS" ]; then
+    GENERATE_ARGS+=(--spammer-submitters "$SPAMMER_SUBMITTERS")
+fi
+
+if [ -n "$MAX_POOL_BYTES" ]; then
+    GENERATE_ARGS+=(--max-pool-bytes "$MAX_POOL_BYTES")
+fi
+
+STORE_ARGS=()
+if [ "$EXTERNAL_STORE" = true ]; then
+    case "$STORE_URL" in
+        http://?*|https://?*) EXPLORER_STORE_URL=$STORE_URL ;;
+        *)
+            echo "external store URL must start with http:// or https://" >&2
+            exit 2
+            ;;
+    esac
+    STORE_ARGS+=(--chain-indexer-url "$STORE_URL")
+else
+    STORE_ARGS+=(
+        --chain-indexer-instance-type c8id.4xlarge
+        --chain-indexer-storage-size 50
+        --chain-indexer-storage-iops 3000
+        --chain-indexer-db-parallelism 12
+    )
+fi
+
 # 1. Generate the deployment bundle (./deploy must not exist).
 if [ -d ./deploy ]; then
     read -r -p "./deploy exists — remove and regenerate? [y/N] " answer
     [ "$answer" = "y" ] || exit 1
     rm -rf ./deploy
 fi
-# ~49k spammer accounts reaches ~250k TPS (lowered to avoid overwhelming
-# simulator)
-cargo run --bin constantinople-deploy -- generate \
-    --validators 50 --relayer --spammer --indexer \
-    --spammer-accounts 4096 --spammer-accounts-jitter 0.1 \
-    --spammer-rayon-threads 14 \
-    --output-dir ./deploy --worker-threads 3 --rayon-threads 13 \
-    --public-key-cache-size 5000000 \
-    --max-propose-bytes 16777216 \
+
+cargo run --bin constantinople-deploy -- generate "${GENERATE_ARGS[@]}" \
     remote \
-    --http-cidr 0.0.0.0/0 --regions us-east-1,us-west-2 \
-    --instance-type c8a.4xlarge --storage-size 150 --storage-throughput 500 \
+    --http-cidr 0.0.0.0/0 --regions "$REGIONS" \
+    --instance-type c8a.4xlarge --storage-size "$STORAGE_SIZE" --storage-throughput 500 \
     --monitoring-instance-type c8a.4xlarge --monitoring-storage-size 100 \
-    --chain-indexer-instance-type c8id.4xlarge \
-    --chain-indexer-storage-size 50 --chain-indexer-storage-iops 3000 \
-    --chain-indexer-db-parallelism 12 \
+    "${STORE_ARGS[@]}" \
     --dashboard ./dashboard.json --traces 1
 
-# 2. Build binaries into ./deploy. The fleet is c8a (AMD/znver5); the
-#    chain-indexer host is c8id (Intel Granite Rapids) so its store lives on
-#    local NVMe instead of EBS. The intel chain-indexer build must come last:
-#    both recipes write deploy/chain-indexer.
+# 2. Build binaries into ./deploy.
 just validator-amd-binary spammer-amd-binary metadata-indexer-amd-binary qmdb-indexer-amd-binary
-just chain-indexer-intel-binary
+
+# The managed chain-indexer uses Intel. Its build must remain last because
+# both indexer recipes write deploy/chain-indexer.
+if [ "$EXTERNAL_STORE" = false ]; then
+    just chain-indexer-intel-binary
+fi
 
 # 3. Create the deployment.
 (cd deploy && deployer aws create --config config.yaml)
@@ -41,7 +147,6 @@ just chain-indexer-intel-binary
 TAG=$(yq -r '.tag' deploy/config.yaml)
 HOSTS=$HOME/.commonware_deployer/$TAG/hosts.yaml
 
-CHAIN_IP=$(yq -r '.hosts[] | select(.name=="chain-indexer") | .ip' "$HOSTS")
 SQL_IP=$(yq -r '.hosts[] | select(.name=="metadata-indexer") | .ip' "$HOSTS")
 QMDB_IP=$(yq -r '.hosts[] | select(.name=="qmdb-indexer") | .ip' "$HOSTS")
 
@@ -50,7 +155,14 @@ RELAYER_NAME=$(for f in deploy/*.yaml; do
 done)
 RELAYER_IP=$(yq -r ".hosts[] | select(.name==\"$RELAYER_NAME\") | .ip" "$HOSTS")
 
-for v in CHAIN_IP SQL_IP QMDB_IP RELAYER_IP; do
+REQUIRED_IPS=(SQL_IP QMDB_IP RELAYER_IP)
+if [ "$EXTERNAL_STORE" = false ]; then
+    CHAIN_IP=$(yq -r '.hosts[] | select(.name=="chain-indexer") | .ip' "$HOSTS")
+    EXPLORER_STORE_URL=http://$CHAIN_IP:8090
+    REQUIRED_IPS+=(CHAIN_IP)
+fi
+
+for v in "${REQUIRED_IPS[@]}"; do
     [ -n "${!v}" ] || { echo "missing $v in $HOSTS" >&2; exit 1; }
 done
 
@@ -58,7 +170,7 @@ SIMPLEX_VERIFICATION_MATERIAL=$(tr -d '[:space:]' < deploy/simplex-verification-
 
 VITE_SQL_URL=http://$SQL_IP:8091 \
 VITE_QMDB_URL=http://$QMDB_IP:8092 \
-VITE_STORE_URL=http://$CHAIN_IP:8090 \
+VITE_STORE_URL="$EXPLORER_STORE_URL" \
 VITE_MEMPOOL_URL=http://$RELAYER_IP:8080 \
 VITE_SIMPLEX_VERIFICATION_MATERIAL=$SIMPLEX_VERIFICATION_MATERIAL \
 npm --prefix explorer run dev

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ fmt-check:
 
 # Lint the workspace
 lint: fmt-check docs-check
-  cargo +nightly clippy --workspace --all --all-features --all-targets -- -D warnings
+  RUSTFLAGS="-Znext-solver=coherence" cargo +nightly clippy --workspace --all --all-features --all-targets -- -D warnings
 
 # Run Rust tests
 test *args='': docs-test


### PR DESCRIPTION
Allows for use/specification of:
- External `exoware` store endpoint rather than self-hosted simulator
- Number of validators
- Number of spammer accounts/submitters
- AWS regions
- Instance disk sizes

Bases the `maximum_honest_shard_size` on the max block size rather than hard coding. 