### PR TITLE
Remove two per-transaction allocations from block decoding

### DIFF
--- a/bin/deploy/src/remote.rs
+++ b/bin/deploy/src/remote.rs
@@ -178,7 +178,7 @@ fn build_validators(
         let config_name = format!("{public_key_hex}.yaml");
 
         validators.push(GeneratedValidator {
-            public_key_hex: public_key_hex.clone(),
+            public_key_hex,
             config_name: config_name.clone(),
             config_file: output_dir.join(config_name),
             config,
@@ -236,7 +236,7 @@ fn build_secondaries(
         let config_name = format!("{public_key_hex}.yaml");
 
         secondaries.push(GeneratedValidator {
-            public_key_hex: public_key_hex.clone(),
+            public_key_hex,
             config_name: config_name.clone(),
             config_file: output_dir.join(config_name),
             config,

--- a/crates/application/src/consensus/lifecycle.rs
+++ b/crates/application/src/consensus/lifecycle.rs
@@ -151,10 +151,10 @@ where
         St: Strategy,
     {
         // The glue actor retains its own references to the block, so the
-        // header and lazy body are cloned out of the shared reference
-        // (per-transaction refcount bumps) instead of moved.
+        // header and lazy body are cloned out of the shared reference (one
+        // refcount bump each) instead of moved.
         let header = block.header.clone();
-        let body = Arc::new(block.body.clone());
+        let body = block.body.clone();
         drop(block);
 
         // Signature verification needs only the block body, so it starts

--- a/crates/application/src/consensus/lifecycle.rs
+++ b/crates/application/src/consensus/lifecycle.rs
@@ -151,8 +151,8 @@ where
         St: Strategy,
     {
         // The glue actor retains its own references to the block, so the
-        // header and lazy body are cloned out of the shared reference (one
-        // refcount bump each) instead of moved.
+        // header and lazy body are cloned out of the shared reference
+        // (one refcount bump for the body) instead of moved.
         let header = block.header.clone();
         let body = block.body.clone();
         drop(block);

--- a/crates/indexer/src/publisher/block.rs
+++ b/crates/indexer/src/publisher/block.rs
@@ -239,6 +239,7 @@ mod tests {
     use core::num::NonZeroU64;
     use exoware_sql::CellValue;
     use rand::{SeedableRng, rngs::StdRng};
+    use std::sync::Arc;
 
     #[test]
     fn r1_sender_history_uses_account_key() {
@@ -298,7 +299,7 @@ mod tests {
         let block = Sealed::new_unchecked(
             Block {
                 header: test_header(consensus_key.public_key(), 1),
-                body: vec![lazy],
+                body: Arc::new(vec![lazy]),
             },
             sha256::Digest::EMPTY,
         );

--- a/crates/indexer/src/simplex_block.rs
+++ b/crates/indexer/src/simplex_block.rs
@@ -3,6 +3,7 @@ use commonware_codec::{Decode, Encode};
 use commonware_cryptography::{Hasher, PublicKey};
 use constantinople_engine::types::{EngineBlock, EngineHeader};
 use constantinople_primitives::{Block, BlockCfg, LazySignedTransaction, Sealed};
+use std::sync::Arc;
 
 pub(crate) fn encode_simplex_block_parts<H, P>(
     block: &EngineBlock<H, P>,
@@ -29,5 +30,11 @@ where
     let header = header.into_inner();
     let body_cfg = (cfg.max_transactions, ());
     let body = Vec::<LazySignedTransaction<H>>::decode_cfg(body, &body_cfg)?;
-    Ok(Sealed::new_unchecked(Block { header, body }, seal))
+    Ok(Sealed::new_unchecked(
+        Block {
+            header,
+            body: Arc::new(body),
+        },
+        seal,
+    ))
 }

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -12,6 +12,7 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{Digest, Hasher, PublicKey};
 use commonware_utils::range::NonEmptyRange;
+use std::sync::Arc;
 
 /// A block header containing metadata, consensus context, and state commitment roots.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -179,7 +180,12 @@ where
     /// decoding does not pay the per-transaction decode + seal-hash cost on the
     /// caller's thread. Materialization is typically driven in parallel at
     /// verify time via a [`commonware_parallel::Strategy`].
-    pub body: Vec<LazySignedTransaction<H>>,
+    ///
+    /// The body is shared through an `Arc` so readers that need an owned
+    /// handle (for example to hand the body to a thread pool) take one
+    /// reference count, and so the decoded values cached by one reader are
+    /// visible to every other holder of the same block.
+    pub body: Arc<Vec<LazySignedTransaction<H>>>,
 }
 
 /// A sealed canonical block.
@@ -198,7 +204,7 @@ where
         let body: Vec<SignedTransaction<H>> = u.arbitrary()?;
         Ok(Self {
             header: u.arbitrary()?,
-            body: body.into_iter().map(LazySignedTransaction::new).collect(),
+            body: Arc::new(body.into_iter().map(LazySignedTransaction::new).collect()),
         })
     }
 }
@@ -233,7 +239,7 @@ where
     pub fn new(header: Header<C, H::Digest, P>, body: Vec<SignedTransaction<H>>) -> Self {
         Self {
             header,
-            body: body.into_iter().map(LazySignedTransaction::new).collect(),
+            body: Arc::new(body.into_iter().map(LazySignedTransaction::new).collect()),
         }
     }
 }
@@ -273,7 +279,7 @@ where
         let tx_vec_cfg = (cfg.max_transactions, ());
         Ok(Self {
             header: Header::read_cfg(buf, &())?,
-            body: Vec::read_cfg(buf, &tx_vec_cfg)?,
+            body: Arc::new(Vec::read_cfg(buf, &tx_vec_cfg)?),
         })
     }
 }

--- a/crates/primitives/src/signed.rs
+++ b/crates/primitives/src/signed.rs
@@ -19,7 +19,7 @@ use commonware_codec::{
 use commonware_cryptography::{Hasher, PublicKey, Signature, Signer, Verifier};
 use commonware_parallel::Strategy;
 use rand::CryptoRng;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 /// A [`Sealed`] object with an attached signature over its seal.
 #[derive(Debug, Clone)]
@@ -201,7 +201,7 @@ where
     H: Hasher,
 {
     pending: Option<Bytes>,
-    value: Arc<OnceLock<Option<SignedTransaction<H>>>>,
+    value: OnceLock<Option<SignedTransaction<H>>>,
 }
 
 impl<H> LazySignedTransaction<H>
@@ -214,7 +214,7 @@ where
     pub fn new(value: SignedTransaction<H>) -> Self {
         Self {
             pending: None,
-            value: Arc::new(Some(value).into()),
+            value: OnceLock::from(Some(value)),
         }
     }
 
@@ -233,15 +233,9 @@ where
 
     /// Consumes the lazy transaction, returning the decoded value if decoding
     /// succeeds.
-    ///
-    /// Moves the cached value out when this handle is its only owner; clones
-    /// only when the decoded value is still shared with another handle.
     pub fn into_value(self) -> Option<SignedTransaction<H>> {
         self.get()?;
-        match Arc::try_unwrap(self.value) {
-            Ok(value) => value.into_inner().flatten(),
-            Err(shared) => shared.get().expect("value was forced above").clone(),
-        }
+        self.value.into_inner().flatten()
     }
 
     /// Returns the encoded signed transaction bytes without the lazy length prefix.
@@ -258,10 +252,10 @@ where
             .encode()
     }
 
-    fn deferred(bytes: Bytes) -> Self {
+    const fn deferred(bytes: Bytes) -> Self {
         Self {
             pending: Some(bytes),
-            value: Default::default(),
+            value: OnceLock::new(),
         }
     }
 }

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -3,7 +3,7 @@
 use crate::{AccountKey, Sealable, Sealed, TransactionPublicKey, TransactionSignature};
 use bytes::{Buf, BufMut};
 use commonware_codec::{
-    Encode, EncodeSize, Error, FixedSize, Read, ReadExt, Write, types::lazy::Lazy,
+    EncodeFixed, EncodeSize, Error, FixedSize, Read, ReadExt, Write, types::lazy::Lazy,
 };
 use commonware_cryptography::{Digest, Hasher, Signer};
 use core::num::NonZeroU64;
@@ -122,6 +122,14 @@ where
     }
 }
 
+/// Encoded size of a [`Transaction`] in bytes.
+///
+/// Kept as a plain constant (rather than only `<Transaction<D> as FixedSize>::SIZE`)
+/// so it can be used as a const generic argument, which stable Rust does not
+/// allow for associated constants of a generic type.
+const TRANSACTION_SIZE: usize =
+    TransactionPublicKey::SIZE + AccountKey::SIZE + u64::SIZE + u64::SIZE;
+
 /// A transaction on the Constantinople blockchain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Transaction<D: Digest> {
@@ -170,7 +178,7 @@ impl<D: Digest> Transaction<D> {
     ///
     /// [`Digest`]: Digest
     pub fn hash_slow<H: Hasher>(&self, hasher: &mut H) -> H::Digest {
-        hasher.update(&self.encode());
+        hasher.update(&self.encode_fixed::<TRANSACTION_SIZE>());
         hasher.finalize()
     }
 
@@ -202,7 +210,7 @@ impl<D: Digest> Write for Transaction<D> {
 }
 
 impl<D: Digest> FixedSize for Transaction<D> {
-    const SIZE: usize = TransactionPublicKey::SIZE + AccountKey::SIZE + u64::SIZE + u64::SIZE;
+    const SIZE: usize = TRANSACTION_SIZE;
 }
 
 impl<D: Digest> Read for Transaction<D> {


### PR DESCRIPTION
A follower paid two per-transaction heap costs on every block that it didn't need to.

## One allocation per transaction just to build an empty cache

`LazySignedTransaction` kept its decoded value behind an `Arc<OnceLock<..>>`. Every block decode (shard reconstruction, and again when marshal re-reads the finalized block from disk) allocated once per transaction to create that empty cell. The `Arc` only existed so that `verify_child`, which cloned the body element by element, would share the cache with the block.

Now the cache is inline and `Block::body` is `Arc<Vec<LazySignedTransaction>>`. Verify and apply bump one refcount instead of cloning every element, and anything decoded through that handle is visible to every other holder of the block. This also removes the per-transaction `Bytes` promotion that the element-wise clone was triggering.

Once marshal hands the application the same `Arc<Block>` it verified (monorepo follow-up), the shared body also means the mempool's finalized-block decode becomes a cache hit with no further change here.

## `hash_slow` allocated a buffer to hash 82 bytes

`Transaction::hash_slow` called `encode()`, which builds a fresh `BytesMut`, and `Sealed::read` calls it for every decoded transaction. `Transaction` is fixed size, so it now encodes onto a stack array. The size lives in a plain `TRANSACTION_SIZE` const because stable Rust won't accept `Self::SIZE` as a const generic argument.

## Trade-off

`LazySignedTransaction` grows since the decoded value now lives inline. Cloning a materialized lazy copies its value instead of bumping an `Arc`. Nothing hot clones one.
