### PR TITLE
Configure deployment parameters and raise shard limit

### DIFF
--- a/bin/deploy/README.md
+++ b/bin/deploy/README.md
@@ -2,6 +2,15 @@
 
 `constantinople-deploy` generates deployment artifacts for local and remote Constantinople clusters.
 
+At least four validators are required for erasure coding. Shard decoding uses a
+static 32 MiB limit, sized to accommodate shards from 32 MiB transaction proposals
+at the minimum validator count. The deployment script still proposes at most
+16 MiB of transaction bytes per block.
+
+`deploy.sh` accepts `--validators`, `--regions`, `--storage-size`,
+`--spammer-accounts`, `--spammer-submitters`, and `--max-pool-bytes`.
+Run `./deploy.sh --help` for defaults.
+
 ## Local Deployment
 
 Generate a local bundle:
@@ -66,6 +75,10 @@ cargo run --bin constantinople-deploy -- generate \
 The spammer continuously submits ring transfers through the generated relayer.
 Each relayer submitter receives transactions from its own independent set of
 accounts.
+
+`--spammer-submitters N` sets the number of concurrent submitters in both local
+and remote deployments. It defaults to the validator count and must be positive.
+Set it explicitly to keep offered load constant when changing the validator count.
 
 Add `--spammer-accounts-jitter J` (default `0`, no jitter) to randomize each submitter's
 batch size as `accounts + rand(0..=floor(accounts * J))`, where `J` must be in `0..=1`.

--- a/bin/deploy/src/local.rs
+++ b/bin/deploy/src/local.rs
@@ -23,7 +23,6 @@ struct GeneratedValidator {
 
 pub(super) fn generate(args: &GenerateArgs, local: &LocalArgs) {
     validate_generate_args(args);
-    assert!(args.validators >= 1, "need at least one validator");
 
     let output_dir = absolute_path(&args.output_dir);
     ensure_output_dir_missing(&output_dir);
@@ -355,7 +354,9 @@ fn local_run_commands(
             relayer_http_port(args, local).expect("--spammer requires a relayer secondary");
         let network_source = format!(
             "--relayer-url http://127.0.0.1:{} --relayer-submitters {} --relayer-targets {}",
-            relayer_port, args.validators, targets,
+            relayer_port,
+            args.spammer_submitters.unwrap_or(args.validators as usize),
+            targets,
         );
 
         // Place the spammer's metrics port past the primary and secondary ranges
@@ -426,6 +427,7 @@ mod tests {
             spammer_seed_offset: 1000,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
+            spammer_submitters: None,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
             target: GenerateTarget::Local(test_local_args()),
         }
@@ -489,6 +491,26 @@ mod tests {
         assert!(commands[3].contains("--seed-offset 1000"));
         assert!(commands[3].contains("--rayon-threads 2"));
         assert!(commands[3].contains("--accounts-jitter 0"));
+    }
+
+    #[test]
+    fn local_spammer_submitters_override_validator_count() {
+        let mut args = test_args(true);
+        args.relayer = true;
+        args.spammer_submitters = Some(50);
+        let commands = local_run_commands(
+            Path::new("/tmp/configs"),
+            &args,
+            local_args(&args),
+            &[],
+            TEST_SIMPLEX_VERIFICATION_MATERIAL,
+        );
+
+        let spammer = commands
+            .iter()
+            .find(|command| command.contains("constantinople-spammer"))
+            .expect("spammer command should be present");
+        assert!(spammer.contains("--relayer-submitters 50"));
     }
 
     #[test]

--- a/bin/deploy/src/main.rs
+++ b/bin/deploy/src/main.rs
@@ -158,6 +158,10 @@ pub(crate) struct GenerateArgs {
     /// txs per batch.
     #[arg(long, default_value_t = 0.0, value_parser = parse_accounts_jitter)]
     spammer_accounts_jitter: f64,
+    /// Concurrent spammer submitters. Defaults to the validator count.
+    /// Set explicitly to keep offered load independent of validator count.
+    #[arg(long = "spammer-submitters")]
+    spammer_submitters: Option<usize>,
     /// Fully signed local batches to keep ready per spammer submitter.
     #[arg(long, default_value_t = DEFAULT_SPAMMER_PRESIGNED_BATCHES)]
     spammer_presigned_batches: usize,
@@ -616,6 +620,11 @@ pub(crate) fn validate_generate_args(args: &GenerateArgs) {
         !args.spammer || args.relayer,
         "--spammer requires --relayer"
     );
+    assert!(args.validators >= 4, "--validators must be at least 4");
+    assert!(
+        args.spammer_submitters != Some(0),
+        "--spammer-submitters must be at least 1"
+    );
 }
 
 pub(crate) fn generate_local_cluster_material(
@@ -942,6 +951,50 @@ mod tests {
         };
         let generate = *generate;
         assert_eq!(generate.spammer_rayon_threads, 6);
+    }
+
+    #[test]
+    #[should_panic(expected = "--validators must be at least 4")]
+    fn rejects_validator_count_below_coding_minimum() {
+        let cli = Cli::try_parse_from([
+            "constantinople-deploy",
+            "generate",
+            "--validators",
+            "3",
+            "--output-dir",
+            "out",
+            "local",
+        ])
+        .expect("local invocation should parse");
+
+        let Command::Generate(generate) = cli.command else {
+            panic!("expected generate command");
+        };
+
+        super::validate_generate_args(&generate);
+    }
+
+    #[test]
+    #[should_panic(expected = "--spammer-submitters must be at least 1")]
+    fn rejects_zero_spammer_submitters() {
+        let cli = Cli::try_parse_from([
+            "constantinople-deploy",
+            "generate",
+            "--validators",
+            "4",
+            "--output-dir",
+            "out",
+            "--spammer-submitters",
+            "0",
+            "local",
+        ])
+        .expect("local invocation should parse");
+
+        let Command::Generate(generate) = cli.command else {
+            panic!("expected generate command");
+        };
+
+        super::validate_generate_args(&generate);
     }
 
     #[test]

--- a/bin/deploy/src/remote.rs
+++ b/bin/deploy/src/remote.rs
@@ -29,7 +29,6 @@ struct GeneratedValidator {
 
 pub(super) fn generate(args: &GenerateArgs, remote: &RemoteArgs) {
     validate_generate_args(args);
-    assert!(args.validators >= 1, "need at least one validator");
     assert!(!remote.regions.is_empty(), "need at least one region");
     assert!(
         remote.regions.len() <= args.validators as usize,
@@ -278,7 +277,7 @@ fn remote_spammer_config(
         rayon_threads: args.spammer_rayon_threads,
         http_port: remote.http_port,
         relayer_url: relayer_url(args, remote, material),
-        relayer_submitters: args.validators as usize,
+        relayer_submitters: args.spammer_submitters.unwrap_or(args.validators as usize),
         presigned_batches: args.spammer_presigned_batches,
         primary_validators: material.primary_hex(),
         accounts_jitter: args.spammer_accounts_jitter,
@@ -521,6 +520,7 @@ mod tests {
             spammer_seed_offset: 1000,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
+            spammer_submitters: None,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
             target: GenerateTarget::Local(LocalArgs {
                 base_port: 9000,
@@ -690,6 +690,20 @@ mod tests {
             relayed.presigned_batches,
             crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES
         );
+    }
+
+    #[test]
+    fn remote_spammer_submitters_override_validator_count() {
+        let mut args = generate_args();
+        args.spammer = true;
+        args.relayer = true;
+        args.spammer_submitters = Some(50);
+        let remote = remote_args();
+        let material = generate_local_cluster_material(args.validators, total_secondaries(&args));
+
+        let config = remote_spammer_config(&args, &remote, &material);
+
+        assert_eq!(config.relayer_submitters, 50);
     }
 
     #[test]

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -85,6 +85,14 @@ pub const MAX_PENDING_ACKS: NonZero<usize> = NZUsize!(4);
 const WITNESS_ITEMS_PER_SECTION: NonZero<u64> = NZU64!(64);
 const SHARD_BACKGROUND_CHANNEL_CAPACITY: NonZero<usize> = NZUsize!(1024);
 const SHARD_PEER_BUFFER_SIZE: NonZero<usize> = NZUsize!(64);
+
+// Four validators need two original shards, the minimum for any supported set.
+// A 32 MiB transaction proposal adds less than 1 MiB of transaction length
+// prefixes, block headers, and coding metadata. Each shard is therefore below
+// 17 MiB, including Reed-Solomon's even-byte padding. Allow 32 MiB to leave
+// headroom without deriving a limit from each node's proposal configuration.
+const MAXIMUM_SHARD_SIZE: usize = 32 * 1024 * 1024;
+
 const DB_WRITE_BUFFER: NonZero<usize> = NZUsize!(8 * 1024 * 1024);
 const STATE_INIT_CACHE_SIZE: NonZero<usize> = NZUsize!(1 << 18);
 const STATE_SYNC_INITIAL: Duration = Duration::from_secs(1);
@@ -468,7 +476,7 @@ where
                 scheme_provider: provider.clone(),
                 blocker: config.blocker.clone(),
                 shard_codec_cfg: CodecConfig {
-                    maximum_shard_size: 1024 * 1024,
+                    maximum_shard_size: MAXIMUM_SHARD_SIZE,
                 },
                 block_codec_cfg: config.block_codec.clone(),
                 strategy: config.strategy.clone(),
@@ -813,5 +821,81 @@ where
             write_buffer: DB_WRITE_BUFFER,
         },
         commit_codec_config: (),
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use commonware_codec::{Decode, Encode, EncodeSize};
+    use commonware_coding::ReedSolomon;
+    use commonware_consensus::{
+        marshal::coding::types::Shard,
+        simplex::types::Context,
+        types::{Round, View},
+    };
+    use commonware_cryptography::{ed25519, sha256};
+    use commonware_parallel::Sequential;
+    use constantinople_primitives::{Block, Header, Sealable, Transaction, TransactionPublicKey};
+    use std::num::NonZeroU64;
+
+    #[test]
+    fn shard_limit_accepts_large_proposals_with_four_validators() {
+        let signer = ed25519::PrivateKey::from_seed(13);
+        let public_key = TransactionPublicKey::ed25519(signer.public_key());
+        let transaction = Transaction::<sha256::Digest>::new(
+            public_key.clone(),
+            public_key,
+            NonZeroU64::new(1).unwrap(),
+            0,
+        )
+        .seal_and_sign(
+            &signer,
+            constantinople_primitives::TRANSACTION_NAMESPACE,
+            &mut sha256::Sha256::default(),
+        );
+        let proposal_bytes = 32 * 1024 * 1024;
+        let transaction_count = proposal_bytes / transaction.encode_size();
+        let header = Header {
+            context: Context {
+                round: Round::new(Epoch::new(u64::MAX), View::new(u64::MAX)),
+                leader: signer.public_key(),
+                parent: (View::new(u64::MAX), Commitment::default()),
+            },
+            parent: sha256::Digest::EMPTY,
+            height: u64::MAX,
+            timestamp: u64::MAX,
+            state_root: sha256::Digest::EMPTY,
+            state_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+            transactions_root: sha256::Digest::EMPTY,
+            transactions_range: non_empty_range!(u64::MAX - 1, u64::MAX),
+        };
+        let block = Block::new(header, vec![transaction; transaction_count])
+            .seal(&mut sha256::Sha256::default());
+        let coding_config = coding_config_for_participants(4);
+        assert_eq!(coding_config.minimum_shards.get(), 2);
+
+        let coded = EngineCodedBlock::new(block, coding_config, &Sequential);
+        let encoded = coded.shard(0).expect("shard zero should exist").encode();
+        assert!(encoded.len() > 16 * 1024 * 1024);
+        assert!(encoded.len() < 17 * 1024 * 1024);
+
+        type TestShard = Shard<ReedSolomon<sha256::Sha256>, sha256::Sha256>;
+        TestShard::decode_cfg(
+            encoded.clone(),
+            &CodecConfig {
+                maximum_shard_size: MAXIMUM_SHARD_SIZE,
+            },
+        )
+        .expect("the static limit should accept a shard from the largest proposal");
+        assert!(
+            TestShard::decode_cfg(
+                encoded,
+                &CodecConfig {
+                    maximum_shard_size: 1024 * 1024,
+                },
+            )
+            .is_err()
+        );
     }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,60 @@
 #!/usr/bin/env bash
 # Generate, build, deploy, and explore a remote Constantinople testnet.
 set -euo pipefail
+
+usage() {
+    echo "usage $0 [options]" >&2
+    echo "  --validators <count>                    default 50" >&2
+    echo "  --regions <comma-separated-regions>     default us-east-1,us-west-2" >&2
+    echo "  --spammer-accounts <count>              default 4096" >&2
+    echo "  --spammer-submitters <count>            default validator count" >&2
+    echo "  --max-pool-bytes <bytes>                default deploy CLI value" >&2
+    echo "  --storage-size <gib>                    default 150" >&2
+}
+
+if [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+VALIDATORS=50
+REGIONS=us-east-1,us-west-2
+SPAMMER_ACCOUNTS=4096
+SPAMMER_SUBMITTERS=
+MAX_POOL_BYTES=
+STORAGE_SIZE=150
+
+while [ "$#" -gt 0 ]; do
+    option=$1
+    case "$option" in
+        --validators) target=VALIDATORS ;;
+        --regions) target=REGIONS ;;
+        --spammer-accounts) target=SPAMMER_ACCOUNTS ;;
+        --spammer-submitters) target=SPAMMER_SUBMITTERS ;;
+        --max-pool-bytes) target=MAX_POOL_BYTES ;;
+        --storage-size) target=STORAGE_SIZE ;;
+        *)
+            echo "unknown option $option" >&2
+            usage
+            exit 2
+            ;;
+    esac
+    if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "missing value for $option" >&2
+        exit 2
+    fi
+    printf -v "$target" '%s' "$2"
+    shift 2
+done
+
+GENERATE_ARGS=(--validators "$VALIDATORS" --spammer-accounts "$SPAMMER_ACCOUNTS")
+if [ -n "$SPAMMER_SUBMITTERS" ]; then
+    GENERATE_ARGS+=(--spammer-submitters "$SPAMMER_SUBMITTERS")
+fi
+if [ -n "$MAX_POOL_BYTES" ]; then
+    GENERATE_ARGS+=(--max-pool-bytes "$MAX_POOL_BYTES")
+fi
+
 cd "$(dirname "$0")"
 
 # 1. Generate the deployment bundle (./deploy must not exist).
@@ -12,15 +66,15 @@ fi
 # ~49k spammer accounts reaches ~250k TPS (lowered to avoid overwhelming
 # simulator)
 cargo run --bin constantinople-deploy -- generate \
-    --validators 50 --relayer --spammer --indexer \
-    --spammer-accounts 4096 --spammer-accounts-jitter 0.1 \
+    "${GENERATE_ARGS[@]}" --relayer --spammer --indexer \
+    --spammer-accounts-jitter 0.1 \
     --spammer-rayon-threads 14 \
     --output-dir ./deploy --worker-threads 3 --rayon-threads 13 \
     --public-key-cache-size 5000000 \
     --max-propose-bytes 16777216 \
     remote \
-    --http-cidr 0.0.0.0/0 --regions us-east-1,us-west-2 \
-    --instance-type c8a.4xlarge --storage-size 150 --storage-throughput 500 \
+    --http-cidr 0.0.0.0/0 --regions "$REGIONS" \
+    --instance-type c8a.4xlarge --storage-size "$STORAGE_SIZE" --storage-throughput 500 \
     --monitoring-instance-type c8a.4xlarge --monitoring-storage-size 100 \
     --chain-indexer-instance-type c8id.4xlarge \
     --chain-indexer-storage-size 50 --chain-indexer-storage-iops 3000 \


### PR DESCRIPTION
Expose cluster and load parameters in deploy.sh and allow spammer submitters to be set independently of the validator count.

Require at least four validators and raise the static shard decode limit to 32 MiB (sufficient for up to 32 MiB max proposal size at the minimum validator count of 4).