### PR TITLE
Use fresh spammer accounts by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "constantinople-mempool",
  "constantinople-primitives",
  "mimalloc",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",

--- a/bin/deploy/README.md
+++ b/bin/deploy/README.md
@@ -87,6 +87,14 @@ locally per submitter. The spammer still submits only one batch at a time to eac
 Add `--spammer-rayon-threads N` (default `2`) to set the spammer's parallel
 signing thread count in generated local commands and remote `spammer.yaml`.
 
+By default, the spammer selects and logs a fresh account seed whenever the
+process starts. This avoids restarting at nonce zero for accounts used by a
+previous run. Pass `--spammer-seed-offset N` to the deployment generator or
+`--seed-offset N` to the spammer binary when a reproducible account set is
+required. In YAML, set `seed_offset` explicitly. Reusing a seed
+after transactions have been accepted recreates the old accounts and is not
+restart-safe.
+
 You can also run the spammer manually against an existing local cluster:
 
 ```sh

--- a/bin/deploy/src/local.rs
+++ b/bin/deploy/src/local.rs
@@ -353,6 +353,10 @@ fn local_run_commands(
         let targets = relayer_targets.join(",");
         let relayer_port =
             relayer_http_port(args, local).expect("--spammer requires a relayer secondary");
+        let seed_offset = args
+            .spammer_seed_offset
+            .map(|seed_offset| format!(" --seed-offset {seed_offset}"))
+            .unwrap_or_default();
         let network_source = format!(
             "--relayer-url http://127.0.0.1:{} --relayer-submitters {} --relayer-targets {}",
             relayer_port, args.validators, targets,
@@ -368,15 +372,14 @@ fn local_run_commands(
             "cargo run --release --bin constantinople-spammer -- \
              {network_source} \
              --accounts {} \
-             --value {} \
-             --seed-offset {} \
+             --value {}{} \
              --rayon-threads {} \
              --accounts-jitter {} \
              --presigned-batches {} \
              --metrics-port {metrics_port}",
             args.spammer_accounts,
             args.spammer_value,
-            args.spammer_seed_offset,
+            seed_offset,
             args.spammer_rayon_threads,
             args.spammer_accounts_jitter,
             args.spammer_presigned_batches,
@@ -423,7 +426,7 @@ mod tests {
             spammer,
             spammer_accounts: 10,
             spammer_value: 1,
-            spammer_seed_offset: 1000,
+            spammer_seed_offset: None,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
@@ -486,7 +489,7 @@ mod tests {
         assert!(commands[3].contains("--relayer-submitters 2"));
         assert!(commands[3].contains("--accounts 10"));
         assert!(commands[3].contains("--value 1"));
-        assert!(commands[3].contains("--seed-offset 1000"));
+        assert!(!commands[3].contains("--seed-offset"));
         assert!(commands[3].contains("--rayon-threads 2"));
         assert!(commands[3].contains("--accounts-jitter 0"));
     }
@@ -506,6 +509,22 @@ mod tests {
         assert_eq!(commands.len(), 3);
         assert!(commands[2].contains("constantinople"));
         assert!(commands[2].contains("secondary-0.yaml"));
+    }
+
+    #[test]
+    fn local_run_commands_propagate_deterministic_seed_offset() {
+        let mut args = test_args(true);
+        args.relayer = true;
+        args.spammer_seed_offset = Some(2000);
+        let commands = local_run_commands(
+            Path::new("/tmp/configs"),
+            &args,
+            local_args(&args),
+            &[],
+            TEST_SIMPLEX_VERIFICATION_MATERIAL,
+        );
+
+        assert!(commands[3].contains("--seed-offset 2000"));
     }
 
     #[test]

--- a/bin/deploy/src/main.rs
+++ b/bin/deploy/src/main.rs
@@ -146,9 +146,9 @@ pub(crate) struct GenerateArgs {
     /// Transfer value per spam transaction.
     #[arg(long, default_value_t = 1)]
     spammer_value: u64,
-    /// Seed offset for spam account keys.
-    #[arg(long, default_value_t = 1000)]
-    spammer_seed_offset: u64,
+    /// Seed offset for deterministic spam accounts. Omit for fresh accounts.
+    #[arg(long)]
+    spammer_seed_offset: Option<u64>,
     /// Number of rayon threads for spammer parallel signing.
     #[arg(long, default_value_t = DEFAULT_SPAMMER_RAYON_THREADS)]
     spammer_rayon_threads: usize,
@@ -286,8 +286,9 @@ pub(crate) struct SpammerConfig {
     pub accounts: u32,
     /// Transfer value per spam transaction.
     pub value: u64,
-    /// Seed offset for spam account keys.
-    pub seed_offset: u64,
+    /// Explicit seed offset for reproducible spam account keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_offset: Option<u64>,
     /// Number of rayon threads used for parallel signing.
     #[serde(default = "default_spammer_rayon_threads")]
     pub rayon_threads: usize,
@@ -898,6 +899,28 @@ mod tests {
         };
         let generate = *generate;
         assert_eq!(generate.spammer_accounts_jitter, 0.25);
+    }
+
+    #[test]
+    fn parses_deterministic_spammer_seed_offset() {
+        let cli = Cli::try_parse_from([
+            "constantinople-deploy",
+            "generate",
+            "--validators",
+            "4",
+            "--output-dir",
+            "out",
+            "--spammer-seed-offset",
+            "2000",
+            "local",
+        ])
+        .expect("local invocation should parse");
+
+        let Command::Generate(generate) = cli.command else {
+            panic!("expected generate command");
+        };
+        let generate = *generate;
+        assert_eq!(generate.spammer_seed_offset, Some(2000));
     }
 
     #[test]

--- a/bin/deploy/src/remote.rs
+++ b/bin/deploy/src/remote.rs
@@ -518,7 +518,7 @@ mod tests {
             spammer: false,
             spammer_accounts: 10,
             spammer_value: 1,
-            spammer_seed_offset: 1000,
+            spammer_seed_offset: None,
             spammer_rayon_threads: crate::DEFAULT_SPAMMER_RAYON_THREADS,
             spammer_accounts_jitter: 0.0,
             spammer_presigned_batches: crate::DEFAULT_SPAMMER_PRESIGNED_BATCHES,
@@ -658,6 +658,22 @@ mod tests {
     }
 
     #[test]
+    fn remote_spammer_config_propagates_deterministic_seed_offset() {
+        let mut args = generate_args();
+        args.spammer = true;
+        args.relayer = true;
+        args.spammer_seed_offset = Some(2000);
+        let remote = remote_args();
+        let material = generate_local_cluster_material(args.validators, total_secondaries(&args));
+
+        let config = remote_spammer_config(&args, &remote, &material);
+        let yaml = serde_yaml::to_value(&config).expect("spammer config should serialize");
+
+        assert_eq!(config.seed_offset, Some(2000));
+        assert_eq!(yaml["seed_offset"].as_u64(), Some(2000));
+    }
+
+    #[test]
     fn remote_spammer_requires_relayer() {
         let mut args = generate_args();
         args.spammer = true;
@@ -685,6 +701,9 @@ mod tests {
 
         assert_eq!(relayed.relayer_url, format!("http://{relayer_key}:8080"));
         assert_eq!(relayed.relayer_submitters, args.validators as usize);
+        assert!(relayed.seed_offset.is_none());
+        let yaml = serde_yaml::to_string(&relayed).expect("spammer config should serialize");
+        assert!(!yaml.contains("seed_offset"));
         assert_eq!(relayed.rayon_threads, crate::DEFAULT_SPAMMER_RAYON_THREADS);
         assert_eq!(
             relayed.presigned_batches,

--- a/bin/spammer/Cargo.toml
+++ b/bin/spammer/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 serde_yaml.workspace = true
 reqwest.workspace = true
+rand = { workspace = true, features = ["sys_rng"] }
 
 [[bin]]
 name = "constantinople-spammer"

--- a/bin/spammer/src/accounts.rs
+++ b/bin/spammer/src/accounts.rs
@@ -1,6 +1,7 @@
-//! Deterministic spam account generation.
+//! Spammer account generation and seed selection.
 
 use commonware_cryptography::{Signer, ed25519};
+use rand::{Rng, RngExt};
 
 /// A spam account with its signing key.
 pub struct SpamAccount {
@@ -21,6 +22,32 @@ pub fn generate_accounts(count: u32, seed_offset: u64) -> Vec<SpamAccount> {
             }
         })
         .collect()
+}
+
+/// Selects a seed range large enough for every submitter account.
+pub fn resolve_seed_offset(
+    configured: Option<u64>,
+    accounts_per_submitter: u32,
+    submitters: usize,
+    rng: &mut impl Rng,
+) -> u64 {
+    let submitters = u64::try_from(submitters).expect("submitter count must fit in u64");
+    let total_accounts = u64::from(accounts_per_submitter)
+        .checked_mul(submitters)
+        .expect("total account count overflow");
+    assert!(total_accounts > 0, "need at least one spam account");
+
+    let max_seed_offset = u64::MAX - (total_accounts - 1);
+    configured.map_or_else(
+        || rng.random_range(0..=max_seed_offset),
+        |seed_offset| {
+            assert!(
+                seed_offset <= max_seed_offset,
+                "seed offset does not leave room for every spam account"
+            );
+            seed_offset
+        },
+    )
 }
 
 #[cfg(test)]
@@ -53,5 +80,58 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn explicit_seed_offset_is_deterministic() {
+        let mut rng = commonware_utils::test_rng();
+        let seed_offset = resolve_seed_offset(Some(42), 10, 4, &mut rng);
+
+        assert_eq!(seed_offset, 42);
+    }
+
+    #[test]
+    fn fresh_seed_offsets_change_between_starts() {
+        let mut rng = commonware_utils::test_rng();
+        let first = resolve_seed_offset(None, 10, 4, &mut rng);
+        let second = resolve_seed_offset(None, 10, 4, &mut rng);
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn explicit_seed_offset_can_use_the_last_seed() {
+        let mut rng = commonware_utils::test_rng();
+        let seed_offset = resolve_seed_offset(Some(u64::MAX - 5), 2, 3, &mut rng);
+        let last_submitter = generate_accounts(2, seed_offset + 4);
+
+        assert_eq!(
+            last_submitter[1].public_key,
+            ed25519::PrivateKey::from_seed(u64::MAX).public_key()
+        );
+    }
+
+    #[test]
+    fn random_seed_offset_leaves_room_for_every_account() {
+        let mut rng = commonware_utils::test_rng();
+        let accounts_per_submitter = 10;
+        let submitters = 4;
+        let seed_offset = resolve_seed_offset(None, accounts_per_submitter, submitters, &mut rng);
+        let total_accounts = u64::from(accounts_per_submitter)
+            * u64::try_from(submitters).expect("submitter count must fit");
+        let max_seed_offset = u64::MAX - (total_accounts - 1);
+        let last_seed = seed_offset
+            .checked_add(total_accounts - 1)
+            .expect("selected range must fit");
+
+        assert!(seed_offset <= max_seed_offset);
+        assert_eq!(last_seed - seed_offset, total_accounts - 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "seed offset does not leave room for every spam account")]
+    fn explicit_seed_offset_rejects_account_range_overflow() {
+        let mut rng = commonware_utils::test_rng();
+        resolve_seed_offset(Some(u64::MAX - 4), 2, 3, &mut rng);
     }
 }

--- a/bin/spammer/src/cli.rs
+++ b/bin/spammer/src/cli.rs
@@ -46,9 +46,9 @@ pub struct Cli {
     #[arg(long, default_value_t = 1)]
     pub value: u64,
 
-    /// Seed offset for spam account keys (avoids collision with validator keys).
-    #[arg(long, default_value_t = 1000)]
-    pub seed_offset: u64,
+    /// Seed offset for deterministic spam accounts. Omit for fresh accounts.
+    #[arg(long)]
+    pub seed_offset: Option<u64>,
 
     /// Number of rayon threads for parallel signing.
     #[arg(long, default_value_t = crate::config::DEFAULT_RAYON_THREADS)]
@@ -95,6 +95,21 @@ mod tests {
         );
         assert!(cli.relayer_targets.is_empty());
         assert!(cli.hosts.is_none());
+        assert!(cli.seed_offset.is_none());
+    }
+
+    #[test]
+    fn parses_deterministic_seed_offset() {
+        let cli = Cli::try_parse_from([
+            "constantinople-spammer",
+            "--relayer-url",
+            "http://127.0.0.1:8084",
+            "--seed-offset",
+            "2000",
+        ])
+        .expect("relayer invocation should parse");
+
+        assert_eq!(cli.seed_offset, Some(2000));
     }
 
     #[test]

--- a/bin/spammer/src/config.rs
+++ b/bin/spammer/src/config.rs
@@ -15,7 +15,8 @@ pub const DEFAULT_RAYON_THREADS: usize = 2;
 pub struct SpammerConfig {
     pub accounts: u32,
     pub value: u64,
-    pub seed_offset: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_offset: Option<u64>,
     /// Number of rayon threads used for parallel signing.
     #[serde(default = "default_rayon_threads")]
     pub rayon_threads: usize,
@@ -95,7 +96,7 @@ mod tests {
         let config = SpammerConfig {
             accounts: 20,
             value: 5,
-            seed_offset: 2000,
+            seed_offset: Some(2000),
             rayon_threads: 6,
             http_port: 9090,
             relayer_url: "http://relayer:8080".to_string(),
@@ -123,9 +124,31 @@ mod tests {
     fn config_yaml_defaults_optional_fields_when_absent() {
         let yaml = "accounts: 10\nvalue: 1\nseed_offset: 1000\nhttp_port: 8080\nrelayer_url: http://127.0.0.1:8084\n";
         let parsed: SpammerConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(parsed.seed_offset, Some(1000));
         assert_eq!(parsed.rayon_threads, DEFAULT_RAYON_THREADS);
         assert_eq!(parsed.presigned_batches, DEFAULT_PRESIGNED_BATCHES);
         assert_eq!(parsed.accounts_jitter, 0.0);
+    }
+
+    #[test]
+    fn config_yaml_omits_random_seed_offset() {
+        let config = SpammerConfig {
+            accounts: 20,
+            value: 5,
+            seed_offset: None,
+            rayon_threads: 6,
+            http_port: 9090,
+            relayer_url: "http://relayer:8080".to_string(),
+            relayer_submitters: 4,
+            presigned_batches: DEFAULT_PRESIGNED_BATCHES,
+            primary_validators: vec!["deadbeef".to_string()],
+            accounts_jitter: 0.25,
+        };
+        let yaml = serde_yaml::to_string(&config).expect("serialize");
+
+        assert!(!yaml.contains("seed_offset"));
+        let parsed: SpammerConfig = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert!(parsed.seed_offset.is_none());
     }
 
     #[test]

--- a/bin/spammer/src/main.rs
+++ b/bin/spammer/src/main.rs
@@ -1,7 +1,7 @@
 //! Constantinople spam bot binary.
 //!
-//! Generates deterministic accounts and submits ring-transfer transactions to
-//! the relayer in a continuous loop.
+//! Generates accounts and submits ring-transfer transactions to the relayer in
+//! a continuous loop.
 //!
 //! Each target gets its own independent account set. A local signer keeps one
 //! batch ready while the submitter has one batch in flight, hiding signing
@@ -13,13 +13,14 @@ mod config;
 mod signer;
 mod submitter;
 
-use accounts::{SpamAccount, generate_accounts};
+use accounts::{SpamAccount, generate_accounts, resolve_seed_offset};
 use clap::Parser;
 use cli::Cli;
 use commonware_runtime::{Runner as _, Strategizer as _, Supervisor as _, tokio::telemetry};
 use commonware_utils::NZUsize;
 use constantinople_primitives::DEFAULT_ACCOUNT_BALANCE;
 use core::num::NonZeroU64;
+use rand::{rand_core::UnwrapErr, rngs::SysRng};
 use signer::{Tx, sign_batch};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -98,6 +99,12 @@ fn main() {
         "transfer value ({value}) must be <= DEFAULT_ACCOUNT_BALANCE ({DEFAULT_ACCOUNT_BALANCE})"
     );
     let value = NonZeroU64::new(value).expect("checked above");
+    let seed_offset = resolve_seed_offset(
+        seed_offset,
+        accounts_count,
+        relayer_submitters,
+        &mut UnwrapErr(SysRng),
+    );
 
     let runtime_cfg = commonware_runtime::tokio::Config::default();
     let runner = commonware_runtime::tokio::Runner::new(runtime_cfg);
@@ -185,7 +192,9 @@ async fn run_relayer_mode(
     let start = Instant::now();
 
     for index in 0..relayer_submitters {
-        let account_offset = seed_offset + (index as u64) * u64::from(accounts_count);
+        let account_index =
+            u64::try_from(index).expect("submitter count checked during seed selection");
+        let account_offset = seed_offset + account_index * u64::from(accounts_count);
         let accounts = generate_accounts(accounts_count, account_offset);
         let target = relayer_target_for(&relayer_targets, index);
         let submitter = RelayerSubmitter::new(relayer_url.clone(), stats.clone(), index, target);
@@ -289,10 +298,7 @@ fn relayer_target_for(targets: &[String], index: usize) -> Option<String> {
     targets.get(index % targets.len()).cloned()
 }
 
-/// Tiny inline xorshift64 used to jitter per-batch sizes. We don't pull
-/// `rand` in here because we only need a few bits per submission and the
-/// statistical quality of xorshift is more than sufficient for visual block
-/// size variance.
+/// Keeps per-batch jitter reproducible from the selected account seed.
 struct JitterRng {
     state: u64,
 }


### PR DESCRIPTION
Select and log a fresh account seed at startup while preserving explicit deterministic seeds. Validate the complete account range across submitters.

Make `seed_offset` optional in YAML and omit the seed from generated commands and configs by default.

This makes the default spammer deploy more robust to restarts. Previously, a restart would cause the same accounts to be used but start from nonce 0, causing nonce conflicts.