### PR TITLE
Fix local chain indexer default metrics port collision

### DIFF
--- a/bin/deploy/README.md
+++ b/bin/deploy/README.md
@@ -149,8 +149,11 @@ relayer is `secondary-1`.
 
 The printed `mprocs` command list grows by four entries:
 
-- `cargo run --release -p constantinople-indexer --bin chain-indexer -- --port 8090 --data-dir ./local/chain-indexer`
-  — the simulator-backed shared store. `--chain-indexer-port` overrides the port.
+- `cargo run --release -p constantinople-indexer --bin chain-indexer -- --port 8090 --metrics-port 9097 --data-dir ./local/chain-indexer`
+  runs the simulator-backed shared store. `--chain-indexer-port` overrides the Store port.
+  The metrics port follows the validator, secondary, and spammer metrics range
+  starting at `--base-metrics-port`. Direct invocations accept `--metrics-port`,
+  and YAML configs accept `metrics_port`. Both default to `9090` when omitted.
 - `cargo run --release -p constantinople-indexer --bin metadata-indexer -- --store-url http://127.0.0.1:8090 --port 8091`
   — the metadata query/stream service. `--metadata-indexer-port` overrides the port.
 - `cargo run --release -p constantinople-indexer --bin qmdb-indexer -- --store-url http://127.0.0.1:8090 --port 8092`

--- a/bin/deploy/src/local.rs
+++ b/bin/deploy/src/local.rs
@@ -306,14 +306,16 @@ fn local_run_commands(
 
     if indexer_enabled(args) {
         let data_dir = output_dir.join(CHAIN_INDEXER_DATA_DIR);
+        let metrics_port = local_chain_indexer_metrics_port(args, local);
         let db_parallelism = local
             .chain_indexer_db_parallelism
             .map(|jobs| format!(" --db-parallelism {jobs}"))
             .unwrap_or_default();
         commands.push(format!(
-            "cargo run --release -p constantinople-indexer --bin {} -- --port {} --data-dir {}{}",
+            "cargo run --release -p constantinople-indexer --bin {} -- --port {} --metrics-port {} --data-dir {}{}",
             CHAIN_INDEXER_BINARY_FILE,
             local.chain_indexer_port,
+            metrics_port,
             data_dir.display(),
             db_parallelism,
         ));
@@ -386,6 +388,21 @@ fn local_run_commands(
     commands
 }
 
+fn local_chain_indexer_metrics_port(args: &GenerateArgs, local: &LocalArgs) -> u16 {
+    let validator_span = u16::try_from(args.validators).expect("validator count exceeds u16");
+    let secondary_span =
+        u16::try_from(total_secondaries(args)).expect("secondary count exceeds u16");
+    let spammer_span = u16::from(args.spammer);
+    let offset = validator_span
+        .checked_add(secondary_span)
+        .and_then(|offset| offset.checked_add(spammer_span))
+        .expect("local metrics port offset overflow");
+    local
+        .base_metrics_port
+        .checked_add(offset)
+        .expect("chain-indexer metrics port overflow")
+}
+
 fn relayer_http_port(args: &GenerateArgs, local: &LocalArgs) -> Option<u16> {
     args.relayer.then(|| {
         let relayer_index = u16::from(args.indexer);
@@ -395,7 +412,9 @@ fn relayer_http_port(args: &GenerateArgs, local: &LocalArgs) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_secondaries, build_validators, local_run_commands};
+    use super::{
+        build_secondaries, build_validators, local_chain_indexer_metrics_port, local_run_commands,
+    };
     use crate::{
         GenerateArgs, GenerateTarget, LocalArgs, StartupModeConfig, default_max_pool_bytes,
         default_max_propose_bytes, default_page_cache_bytes, default_public_key_cache_size,
@@ -647,7 +666,50 @@ mod tests {
             .find(|c| c.contains("--bin chain-indexer"))
             .expect("chain-indexer command should be present");
         assert!(indexer_cmd.contains("--port 8090"));
+        assert!(indexer_cmd.contains("--metrics-port 9094"));
         assert!(indexer_cmd.contains("--data-dir /tmp/configs/chain-indexer"));
+    }
+
+    #[test]
+    fn local_indexer_metrics_port_follows_enabled_services() {
+        for (validators, relayer, spammer, base_port, expected_port) in [
+            (4, true, true, 9090, 9097),
+            (2, false, false, 12000, 12003),
+            (4, true, false, 12000, 12006),
+        ] {
+            let mut args = test_args(spammer);
+            args.validators = validators;
+            args.indexer = true;
+            args.relayer = relayer;
+            let GenerateTarget::Local(local) = &mut args.target else {
+                panic!("test_args must construct a Local target");
+            };
+            local.base_metrics_port = base_port;
+            let commands = local_run_commands(
+                Path::new("/tmp/configs"),
+                &args,
+                local_args(&args),
+                &[],
+                TEST_SIMPLEX_VERIFICATION_MATERIAL,
+            );
+            let indexer_cmd = commands
+                .iter()
+                .find(|command| command.contains("--bin chain-indexer"))
+                .expect("chain-indexer command should be present");
+
+            assert!(indexer_cmd.contains(&format!("--metrics-port {expected_port}")));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "chain-indexer metrics port overflow")]
+    fn local_indexer_metrics_port_rejects_overflow() {
+        let mut args = test_args(false);
+        args.indexer = true;
+        let mut local = test_local_args();
+        local.base_metrics_port = u16::MAX;
+
+        local_chain_indexer_metrics_port(&args, &local);
     }
 
     #[test]

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -41,6 +41,7 @@ const ROCKS_COMPACTION_READAHEAD_SIZE: usize = 8 * 1024 * 1024;
 const ROCKS_MAX_COMMIT_BATCH_BYTES: usize = 256 * 1024 * 1024;
 const ROCKS_STAGE_WORKERS: usize = 4;
 const ROCKS_MAX_QUEUED_WAVES: usize = 4;
+const DEFAULT_METRICS_PORT: u16 = 9090;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -56,6 +57,10 @@ struct Cli {
     /// TCP port to bind on `0.0.0.0`.
     #[arg(long, default_value_t = 8090)]
     port: u16,
+
+    /// TCP port for Prometheus metrics.
+    #[arg(long, default_value_t = DEFAULT_METRICS_PORT)]
+    metrics_port: u16,
 
     /// Directory used by the simulator's RocksDB engine.
     #[arg(long, conflicts_with_all = ["hosts", "config"])]
@@ -78,10 +83,16 @@ struct Cli {
 #[derive(Debug, Deserialize)]
 struct DeployerConfig {
     port: u16,
+    #[serde(default = "default_metrics_port")]
+    metrics_port: u16,
     data_dir: PathBuf,
     /// Leaves RocksDB's stock parallelism when omitted.
     #[serde(default)]
     db_parallelism: Option<i32>,
+}
+
+const fn default_metrics_port() -> u16 {
+    DEFAULT_METRICS_PORT
 }
 
 fn load_deployer_config(path: &Path) -> DeployerConfig {
@@ -100,12 +111,13 @@ fn resolve_data_dir(config_path: &Path, data_dir: PathBuf) -> PathBuf {
         .join(data_dir)
 }
 
-fn load_settings(cli: Cli) -> (PathBuf, u16, Option<i32>) {
+fn load_settings(cli: Cli) -> (PathBuf, u16, u16, Option<i32>) {
     if let Some(config_path) = cli.config {
         let config = load_deployer_config(&config_path);
         return (
             resolve_data_dir(&config_path, config.data_dir),
             config.port,
+            config.metrics_port,
             config.db_parallelism,
         );
     }
@@ -114,6 +126,7 @@ fn load_settings(cli: Cli) -> (PathBuf, u16, Option<i32>) {
         cli.data_dir
             .expect("clap should require --data-dir or --hosts"),
         cli.port,
+        cli.metrics_port,
         cli.db_parallelism,
     )
 }
@@ -122,8 +135,6 @@ async fn health() -> &'static str {
     "ok"
 }
 
-/// Port the deployer scrapes for binary metrics.
-const METRICS_PORT: u16 = 9090;
 /// Ingest latency buckets: 1ms to 60s.
 const INGEST_DURATION_BUCKETS: [f64; 12] = [
     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0, 15.0, 60.0,
@@ -229,6 +240,7 @@ fn chain_indexer_rocks_config(db_parallelism: Option<i32>) -> RocksConfig {
 async fn run(
     data_dir: &Path,
     port: u16,
+    metrics_port: u16,
     db_parallelism: Option<i32>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let engine = Arc::new(RocksStore::open(
@@ -243,7 +255,7 @@ async fn run(
         .layer(middleware::from_fn_with_state(metrics, track_ingest))
         .layer(CorsLayer::very_permissive());
 
-    let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], METRICS_PORT));
+    let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], metrics_port));
     let metrics_app = Router::new()
         .route("/metrics", get(serve_metrics))
         .with_state(registry);
@@ -263,7 +275,7 @@ async fn run(
 
 fn main() {
     let cli = Cli::parse();
-    let (data_dir, port, db_parallelism) = load_settings(cli);
+    let (data_dir, port, metrics_port, db_parallelism) = load_settings(cli);
     fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
@@ -276,7 +288,7 @@ fn main() {
         .expect("failed to build tokio runtime");
 
     runtime.block_on(async move {
-        if let Err(error) = run(&data_dir, port, db_parallelism).await {
+        if let Err(error) = run(&data_dir, port, metrics_port, db_parallelism).await {
             eprintln!("chain-indexer exited with error: {error}");
             std::process::exit(1);
         }
@@ -285,7 +297,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, load_settings};
+    use super::{Cli, DEFAULT_METRICS_PORT, load_settings};
     use clap::Parser;
     use std::{
         fs,
@@ -313,9 +325,26 @@ mod tests {
         .expect("local invocation should parse");
 
         assert_eq!(cli.port, 8090);
+        assert_eq!(cli.metrics_port, DEFAULT_METRICS_PORT);
         assert_eq!(cli.data_dir, Some(PathBuf::from("./chain-indexer")));
         assert!(cli.hosts.is_none());
         assert!(cli.config.is_none());
+    }
+
+    #[test]
+    fn local_settings_use_explicit_metrics_port() {
+        let cli = Cli::try_parse_from([
+            "chain-indexer",
+            "--metrics-port",
+            "19090",
+            "--data-dir",
+            "./chain-indexer",
+        ])
+        .expect("local invocation should parse");
+        let (_, port, metrics_port, _) = load_settings(cli);
+
+        assert_eq!(port, 8090);
+        assert_eq!(metrics_port, 19_090);
     }
 
     #[test]
@@ -349,9 +378,10 @@ mod tests {
         ])
         .expect("deployer invocation should parse");
 
-        let (data_dir, port, db_parallelism) = load_settings(cli);
+        let (data_dir, port, metrics_port, db_parallelism) = load_settings(cli);
 
         assert_eq!(port, 18_090);
+        assert_eq!(metrics_port, DEFAULT_METRICS_PORT);
         assert_eq!(db_parallelism, None);
         assert_eq!(
             data_dir,
@@ -359,5 +389,29 @@ mod tests {
         );
 
         let _ = fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn deployer_settings_use_explicit_metrics_port() {
+        let config_path = temp_path("chain-indexer-metrics", ".yaml");
+        fs::write(
+            &config_path,
+            "port: 18090\nmetrics_port: 19090\ndata_dir: chain-indexer\n",
+        )
+        .expect("config should write");
+        let cli = Cli::try_parse_from([
+            "chain-indexer",
+            "--hosts",
+            "hosts.yaml",
+            "--config",
+            config_path.to_str().expect("utf-8 path"),
+        ])
+        .expect("deployer invocation should parse");
+        let (_, port, metrics_port, _) = load_settings(cli);
+
+        assert_eq!(port, 18_090);
+        assert_eq!(metrics_port, 19_090);
+
+        fs::remove_file(config_path).expect("config should be removed");
     }
 }


### PR DESCRIPTION
Generated local deployments assigned metrics port 9090 to both the first validator and chain-indexer, causing chain-indexer startup to fail when the validator bound it first. This change makes the chain-indexer metrics port configurable and places it after the validator, secondary, and spammer metrics ports in generated local commands.